### PR TITLE
Add fun meme and golem commands

### DIFF
--- a/commands/golem.ts
+++ b/commands/golem.ts
@@ -1,0 +1,41 @@
+import { type CommandInteraction, SlashCommandBuilder, EmbedBuilder } from 'discord.js';
+
+export const data = new SlashCommandBuilder()
+  .setName('golem')
+  .setDescription('Affiche un golem aléatoire depuis le SRD D&D.');
+
+export async function execute(interaction: CommandInteraction) {
+  const listRes = await fetch('https://www.dnd5eapi.co/api/monsters?name=golem');
+  if (!listRes.ok) {
+    await interaction.reply({ content: "Impossible de récupérer un golem.", ephemeral: true });
+    return;
+  }
+
+  const list = await listRes.json();
+  const golems = list.results;
+  if (!golems || golems.length === 0) {
+    await interaction.reply({ content: "Aucun golem trouvé.", ephemeral: true });
+    return;
+  }
+
+  const random = golems[Math.floor(Math.random() * golems.length)];
+  const detailRes = await fetch(`https://www.dnd5eapi.co${random.url}`);
+  if (!detailRes.ok) {
+    await interaction.reply({ content: "Impossible de récupérer les détails du golem.", ephemeral: true });
+    return;
+  }
+
+  const details = await detailRes.json();
+
+  const embed = new EmbedBuilder()
+    .setColor('#9b59b6')
+    .setTitle(details.name)
+    .setDescription(`${details.size} ${details.type} - ${details.alignment}`)
+    .addFields(
+      { name: 'Points de vie', value: details.hit_points.toString(), inline: true },
+      { name: 'Niveau de défi', value: details.challenge_rating.toString(), inline: true }
+    )
+    .setFooter({ text: 'Source: D&D 5e API' });
+
+  await interaction.reply({ embeds: [embed] });
+}

--- a/commands/meme.ts
+++ b/commands/meme.ts
@@ -1,0 +1,28 @@
+import { type CommandInteraction, SlashCommandBuilder, EmbedBuilder } from 'discord.js';
+
+const subreddits = ['FrenchMemes', 'memesfrancais', 'memesfrancophones', 'france'];
+
+export const data = new SlashCommandBuilder()
+  .setName('meme')
+  .setDescription('Affiche un meme francophone aléatoire.');
+
+export async function execute(interaction: CommandInteraction) {
+  const subreddit = subreddits[Math.floor(Math.random() * subreddits.length)];
+  const response = await fetch(`https://meme-api.com/gimme/${subreddit}`);
+
+  if (!response.ok) {
+    await interaction.reply({ content: "Impossible de récupérer un meme.", ephemeral: true });
+    return;
+  }
+
+  const meme = await response.json();
+
+  const embed = new EmbedBuilder()
+    .setColor('#0099ff')
+    .setTitle(meme.title)
+    .setImage(meme.url)
+    .setURL(meme.postLink)
+    .setFooter({ text: `r/${meme.subreddit} | 👍 ${meme.ups}` });
+
+  await interaction.reply({ embeds: [embed] });
+}


### PR DESCRIPTION
## Summary
- add `/meme` command that fetches random french memes from Meme API
- add `/golem` command that fetches random golems from the D&D 5e API

## Testing
- `npx tsc --noEmit commands/meme.ts commands/golem.ts` *(fails: Cannot find module 'discord.js' or global Promise)*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_686aa14d6b4083218e13846de5a28423