### PR TITLE
fix(release): Kepler 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ---
 
+## [1.0.1] - 2026-07-31 (Stable)
+
+### 🎯 Points clés
+- **Invitations existantes restaurées** dans le classement et les statistiques
+- **Synchronisation à la demande** avant l'affichage de `/invitations`
+- **Identité des embeds harmonisée** avec l'auteur et l'avatar de Kepler
+
+👉 [Voir les notes de version détaillées](changelogs/v1.0.1.md)
+
+### 🐛 Corrigé
+- Le classement des invitations pouvait rester vide lorsque les liens avaient
+  été créés avant l'activation du suivi
+- Les compteurs Discord et les arrivées suivies sont désormais fusionnés sans
+  double comptage
+- Les invitations actives sans utilisation apparaissent également dans le
+  classement
+
+### 🔧 Modifié
+- Les statistiques distinguent les utilisations Discord, les arrivées suivies,
+  les membres encore présents et les départs suivis
+- Les embeds standards affichent l'identité de Kepler tout en conservant leurs
+  footers informatifs
+- Le nom du conteneur Docker est harmonisé avec celui du projet
+
+---
+
 ## [1.0.0] - 2026-07-30 (Stable)
 
 ### 🎯 Points clés

--- a/DISCORD_RELEASE_1.0.1.md
+++ b/DISCORD_RELEASE_1.0.1.md
@@ -1,0 +1,24 @@
+# 🛠️ Kepler 1.0.1 est disponible
+
+Cette mise à jour corrective répare le module d'invitations.
+
+🔗 **Invitations existantes récupérées**
+
+Les liens créés avant l'activation du suivi apparaissent maintenant dans le
+classement, y compris ceux qui n'ont encore aucune utilisation.
+
+📊 **Compteurs plus fiables**
+
+Kepler fusionne les utilisations remontées par Discord avec les arrivées déjà
+suivies, sans les compter deux fois. Les statistiques distinguent aussi les
+arrivées suivies, les membres encore présents et les départs.
+
+🎨 **Embeds harmonisés**
+
+Les embeds standards affichent désormais clairement l'identité de Kepler, sans
+remplacer les footers utiles comme la pagination ou le nom du serveur.
+
+Pour importer les invitations existantes, Kepler doit disposer de la permission
+**Gérer le serveur**.
+
+**Version :** `1.0.1` · **Type :** Correctif · **Canal :** Stable

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,27 +1,25 @@
-# Release Kepler 1.0.0
+# Release Kepler 1.0.1
 
-Ce document décrit la promotion de la branche `v1.0.0` vers la production.
+Ce document décrit la promotion de la branche `v1.0.1` vers la production.
 Dokploy déploie l'environnement de développement depuis `main` et la production
 depuis un tag Git sélectionné manuellement.
 
 ## Avant le merge
 
-- [x] `version.json` annonce `1.0.0` et le canal stable
-- [x] `CHANGELOG.md` et `changelogs/v1.0.0.md` sont à jour
-- [x] La note Discord est prête dans `DISCORD_RELEASE_1.0.0.md`
-- [x] L'ordre des migrations Supabase est documenté
+- [x] `version.json` annonce `1.0.1` et le canal stable
+- [x] `CHANGELOG.md` et `changelogs/v1.0.1.md` sont à jour
+- [x] La note Discord est prête dans `DISCORD_RELEASE_1.0.1.md`
+- [x] Aucune migration Supabase supplémentaire n'est nécessaire
 - [ ] Le type-check Deno passe
 - [ ] L'image Docker se construit
 - [ ] La branche de développement a été testée avec les services externes
-- [ ] La PR `v1.0.0` vers `main` est approuvée et fusionnée
+- [ ] `/invitations classement` récupère les invitations Discord existantes
+- [ ] La PR `v1.0.1` vers `main` est approuvée et fusionnée
 
-## Préparer Supabase PROD
+## Supabase PROD
 
-1. Faire une sauvegarde de la base.
-2. Suivre `database/migrations/README.md` et appliquer chaque migration
-   manquante dans l'ordre.
-3. Vérifier que les nouvelles tables ont la RLS activée.
-4. Vérifier que Kepler utilise la clé serveur `SUPABASE_SERVICE_ROLE_KEY`.
+Aucune nouvelle migration n'est requise depuis la version 1.0.0. Vérifier que
+Kepler utilise toujours la clé serveur `SUPABASE_SERVICE_ROLE_KEY`.
 
 ## Variables Dokploy PROD
 
@@ -46,26 +44,25 @@ Le tag doit être créé uniquement sur le commit de merge présent dans `main` 
 ```bash
 git switch main
 git pull --ff-only origin main
-git tag -a v1.0.0 -m "Kepler 1.0.0"
-git push origin v1.0.0
+git tag -a v1.0.1 -m "Kepler 1.0.1"
+git push origin v1.0.1
 ```
 
-Créer ensuite la release GitHub `v1.0.0` en copiant le contenu de
-`changelogs/v1.0.0.md`. Ne pas marquer la release comme pre-release.
+Créer ensuite la release GitHub `v1.0.1` en copiant le contenu de
+`changelogs/v1.0.1.md`. Ne pas marquer la release comme pre-release.
 
 ## Déploiement Dokploy
 
 1. Ouvrir le service Kepler PROD.
-2. Sélectionner le tag `v1.0.0`.
+2. Sélectionner le tag `v1.0.1`.
 3. Construire et déployer l'image.
 4. Contrôler les logs de démarrage et la connexion Discord.
-5. Vérifier `/help`, `/settings`, `/xp` et `/invitations` sur un serveur pilote.
-6. Vérifier la création d'un ticket et les logs d'auto-modération.
-7. Publier `DISCORD_RELEASE_1.0.0.md` après validation.
+5. Vérifier `/help`, `/settings` et `/invitations` sur un serveur pilote.
+6. Vérifier le classement avec une invitation créée avant le déploiement.
+7. Publier `DISCORD_RELEASE_1.0.1.md` après validation.
 
 ## Retour arrière
 
-En cas d'incident, redéployer le tag stable précédent dans Dokploy. Les
-migrations 1.0.0 sont additives : ne supprimer aucune table ni colonne pendant
-le rollback. Désactiver les nouvelles fonctions dans `/settings` le temps du
-diagnostic.
+En cas d'incident, redéployer le tag stable `v1.0.0` dans Dokploy. La version
+1.0.1 n'ajoute aucune migration et ne nécessite aucun retour arrière de base de
+données.

--- a/changelogs/README.md
+++ b/changelogs/README.md
@@ -14,12 +14,21 @@ Chaque version a son propre fichier markdown avec :
 
 ## 🗂️ Index des versions
 
+### Stable
+- [v1.0.1](v1.0.1.md) - 31 juillet 2026 - **Correctif 1.0.1** ✅ Actuelle
+  - Récupération des invitations déjà présentes
+  - Classement et statistiques corrigés sans double comptage
+  - Identité visuelle des embeds harmonisée
+- [v1.0.0](v1.0.0.md) - 30 juillet 2026 - **Première version stable**
+  - XP, tickets, invitations et auto-modération
+  - Configuration centralisée avec `/settings`
+
 ### Beta
-- [v0.1.5](v0.1.5.md) - 28 juillet 2026 - **Beta 1.5** ✅ Actuelle
+- [v0.1.5](v0.1.5.md) - 28 juillet 2026 - **Beta 1.5**
   - Système complet de tickets
   - Archives et logs d’état
   - Sécurité et panneaux `/settings` renforcés
-- [v0.1.3](v0.1.3.md) - 5 janvier 2026 - **Beta 1.3** ✅ Actuelle
+- [v0.1.3](v0.1.3.md) - 5 janvier 2026 - **Beta 1.3**
   - Statistiques avancées (`/graph`)
   - RGPD complet (`/mesdonnees`)
   - Optimisations images WebP

--- a/changelogs/v1.0.1.md
+++ b/changelogs/v1.0.1.md
@@ -1,0 +1,42 @@
+# Kepler 1.0.1
+
+Date de sortie : 31 juillet 2026
+
+Canal : stable
+
+Cette version corrective rétablit l'affichage des invitations créées avant
+l'activation du suivi de Kepler.
+
+## Invitations
+
+- Synchronisation des invitations Discord avant chaque consultation de
+  `/invitations`
+- Import des liens actifs déjà présents sur le serveur
+- Affichage des invitations encore inutilisées dans le classement
+- Fusion du compteur Discord avec les arrivées suivies, sans double comptage
+- Statistiques détaillées entre utilisations attribuées, arrivées suivies,
+  membres encore présents et départs suivis
+
+La synchronisation nécessite la permission Discord **Gérer le serveur**.
+Sans cette permission, Kepler conserve les données déjà suivies mais ne peut
+pas importer les invitations existantes.
+
+## Interface
+
+- Les embeds créés avec le thème commun affichent désormais l'auteur `Kepler`
+  et l'avatar actuel du bot
+- Les auteurs contextuels et les footers informatifs existants restent
+  prioritaires
+- Le libellé des logs dans `/settings` a été clarifié
+
+## Exploitation
+
+- Le nom du conteneur Docker est harmonisé avec le projet
+- Aucune migration Supabase n'est nécessaire pour cette mise à jour
+
+## Mise à niveau depuis 1.0.0
+
+1. Déployer Kepler `v1.0.1`.
+2. Vérifier que le bot possède la permission **Gérer le serveur**.
+3. Exécuter `/invitations classement` sur un serveur possédant déjà des liens.
+4. Vérifier qu'un lien inutilisé apparaît avec un compteur à zéro.

--- a/commands/administration/settings.ts
+++ b/commands/administration/settings.ts
@@ -2078,7 +2078,7 @@ function sectionLabel(section: ConfigSection): string {
 
 function sectionDescription(section: ConfigSection): string {
     return ({
-        logs: 'Choisissez le salon qui recevra les événements généraux du serveur.',
+        logs: 'Choisissez le salon qui recevra les logs du serveur.',
         moderation: 'Configurez les protections automatiques, leurs exemptions, sanctions et journaux.',
         birthdays: 'Choisissez le salon dans lequel les anniversaires seront annoncés.',
         mute: 'Sélectionnez un rôle existant, créez-en un automatiquement ou utilisez les timeouts Discord.',

--- a/commands/general/invitations.ts
+++ b/commands/general/invitations.ts
@@ -31,14 +31,15 @@ export async function execute(interaction: ChatInputCommandInteraction) {
         return;
     }
     await interaction.deferReply();
+    await interaction.client.inviteManager?.synchronizeGuild(interaction.guild);
 
     if (interaction.options.getSubcommand() === 'classement') {
         const leaderboard = await getInviteLeaderboard(interaction.guild.id);
         const description = leaderboard.length
             ? leaderboard.map((entry, index) =>
-                `**${index + 1}.** <@${entry.inviter_id}> — **${entry.invite_count}** arrivée(s)`
+                `**${index + 1}.** <@${entry.inviter_id}> — **${entry.invite_count}** utilisation(s)`
             ).join('\n')
-            : 'Aucune invitation attribuée pour le moment.';
+            : 'Aucune invitation active attribuable pour le moment.';
         const embed = setRequesterFooter(
             createKeplerEmbed('primary')
                 .setTitle('Classement des invitations')
@@ -57,9 +58,10 @@ export async function execute(interaction: ChatInputCommandInteraction) {
             .setTitle(`Invitations de ${user.username}`)
             .setThumbnail(user.displayAvatarURL({ forceStatic: false }))
             .addFields(
-                { name: 'Arrivées attribuées', value: String(stats.total_invites), inline: true },
+                { name: 'Utilisations attribuées', value: String(stats.total_invites), inline: true },
+                { name: 'Arrivées suivies', value: String(stats.tracked_invites), inline: true },
                 { name: 'Toujours présentes', value: String(stats.active_members), inline: true },
-                { name: 'Départs', value: String(stats.total_invites - stats.active_members), inline: true }
+                { name: 'Départs suivis', value: String(stats.tracked_invites - stats.active_members), inline: true }
             ),
         interaction.user,
         interaction.guild.name

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   deno:
     build: .
-    container_name: kepler-bot-prod
+    container_name: kepler-bot
     restart: always
     environment:
       TOKEN: ${TOKEN}

--- a/docs/DIRECTION-ARTISTIQUE.md
+++ b/docs/DIRECTION-ARTISTIQUE.md
@@ -29,6 +29,9 @@ couleur produite par un utilisateur, un rôle Discord ou un contenu externe.
 ## Embeds et messages
 
 - Un embed standard est créé avec `createKeplerEmbed(tone)`.
+- L'auteur par défaut affiche `Kepler` avec l'avatar actuel du bot. Un auteur
+  contextuel peut le remplacer lorsqu'il identifie réellement un membre, un
+  serveur ou une source externe.
 - `primary` sert aux informations normales, `success` aux confirmations,
   `warning` aux avertissements, `danger` aux erreurs et actions destructives.
 - Un titre décrit le résultat ou l'action, sans ponctuation superflue.
@@ -40,6 +43,8 @@ couleur produite par un utilisateur, un rôle Discord ou un contenu externe.
   `✅` succès, `⚠️` avertissement, `❌` erreur, `ℹ️` information.
 - Les footers utilisent `setRequesterFooter` quand une action est liée à un
   utilisateur.
+- Les footers informatifs existants sont conservés : pagination, nombre
+  d'éléments, version, durée de validité ou nom du serveur.
 
 ## Graphiques
 

--- a/events/core/ready.ts
+++ b/events/core/ready.ts
@@ -10,11 +10,14 @@ import { RGPDManager } from '../../managers/rgpdManager.ts';
 import { XpManager } from '../../managers/xpManager.ts';
 import { ReminderManager } from '../../managers/reminderManager.ts';
 import { InviteManager } from '../../managers/inviteManager.ts';
+import { configureKeplerEmbedIdentity } from '../../utils/theme.ts';
 
 export const name = 'ready';
 export const once = true;
 
 export async function execute(client: Client<true>) {
+    configureKeplerEmbedIdentity(client.user);
+
     logger.success(`Bot connecté: ${client.user.tag}`, undefined, 'BOT');
     logger.info(`Prêt sur ${client.guilds.cache.size} serveur(s)`, undefined, 'BOT');
     

--- a/managers/inviteManager.ts
+++ b/managers/inviteManager.ts
@@ -34,6 +34,10 @@ export class InviteManager {
         await this.refreshGuild(guild);
     }
 
+    async synchronizeGuild(guild: Guild): Promise<void> {
+        await this.refreshGuild(guild);
+    }
+
     async handleInviteCreate(invite: Invite): Promise<void> {
         if (!invite.guild || !('members' in invite.guild)) return;
         const guild = invite.guild;

--- a/utils/invites/service.ts
+++ b/utils/invites/service.ts
@@ -138,29 +138,74 @@ export async function getInviteLeaderboard(
     guildId: string,
     limit = 10
 ): Promise<Array<{ inviter_id: string; invite_count: number }>> {
-    const { data, error } = await supabase.rpc('get_guild_invite_leaderboard', {
-        p_guild_id: guildId,
-        p_limit: limit
-    });
-    if (error) throw new Error(`Classement des invitations impossible : ${error.message}`);
-    return (data ?? []).map((row: { inviter_id: string; invite_count: number | string }) => ({
-        inviter_id: row.inviter_id,
-        invite_count: Number(row.invite_count)
-    }));
+    const [{ data: trackedData, error: trackedError }, { data: inviteData, error: inviteError }] = await Promise.all([
+        supabase.rpc('get_guild_invite_leaderboard', {
+            p_guild_id: guildId,
+            p_limit: 25
+        }),
+        supabase
+            .from('guild_invites')
+            .select('inviter_id, uses')
+            .eq('guild_id', guildId)
+            .is('deleted_at', null)
+            .not('inviter_id', 'is', null)
+    ]);
+    if (trackedError) throw new Error(`Classement des invitations impossible : ${trackedError.message}`);
+    if (inviteError) throw new Error(`Lecture des invitations Discord impossible : ${inviteError.message}`);
+
+    const totals = new Map<string, { tracked: number; discord: number }>();
+    for (const row of trackedData ?? []) {
+        if (!row.inviter_id) continue;
+        totals.set(row.inviter_id, {
+            tracked: Number(row.invite_count ?? 0),
+            discord: totals.get(row.inviter_id)?.discord ?? 0
+        });
+    }
+    for (const row of inviteData ?? []) {
+        if (!row.inviter_id) continue;
+        const current = totals.get(row.inviter_id) ?? { tracked: 0, discord: 0 };
+        current.discord += Number(row.uses ?? 0);
+        totals.set(row.inviter_id, current);
+    }
+
+    return [...totals.entries()]
+        .map(([inviter_id, counts]) => ({
+            inviter_id,
+            // Les arrivées suivies font déjà partie du compteur Discord.
+            invite_count: Math.max(counts.tracked, counts.discord)
+        }))
+        .sort((a, b) => b.invite_count - a.invite_count)
+        .slice(0, Math.max(1, Math.min(limit, 25)));
 }
 
 export async function getInviteMemberStats(
     guildId: string,
     userId: string
-): Promise<{ total_invites: number; active_members: number }> {
-    const { data, error } = await supabase.rpc('get_guild_invite_member_stats', {
-        p_guild_id: guildId,
-        p_user_id: userId
-    });
-    if (error) throw new Error(`Statistiques d'invitations impossibles : ${error.message}`);
-    const row = data?.[0];
+): Promise<{ total_invites: number; tracked_invites: number; active_members: number }> {
+    const [{ data: trackedData, error: trackedError }, { data: inviteData, error: inviteError }] = await Promise.all([
+        supabase.rpc('get_guild_invite_member_stats', {
+            p_guild_id: guildId,
+            p_user_id: userId
+        }),
+        supabase
+            .from('guild_invites')
+            .select('uses')
+            .eq('guild_id', guildId)
+            .eq('inviter_id', userId)
+            .is('deleted_at', null)
+    ]);
+    if (trackedError) throw new Error(`Statistiques d'invitations impossibles : ${trackedError.message}`);
+    if (inviteError) throw new Error(`Lecture des invitations Discord impossible : ${inviteError.message}`);
+
+    const row = trackedData?.[0];
+    const trackedInvites = Number(row?.total_invites ?? 0);
+    const discordUses = (inviteData ?? []).reduce(
+        (total: number, invite: { uses: number | string | null }) => total + Number(invite.uses ?? 0),
+        0
+    );
     return {
-        total_invites: Number(row?.total_invites ?? 0),
+        total_invites: Math.max(trackedInvites, discordUses),
+        tracked_invites: trackedInvites,
         active_members: Number(row?.active_members ?? 0)
     };
 }

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -1,5 +1,8 @@
 import { EmbedBuilder, type User } from 'discord.js';
 
+const KEPLER_AUTHOR_NAME = 'Kepler';
+let keplerAuthorIconURL: string | undefined;
+
 /**
  * Identité visuelle Kepler
  *
@@ -57,9 +60,22 @@ export const KEPLER_MESSAGES = {
     noData: 'ℹ️ Aucune donnée disponible pour cette période.'
 } as const;
 
+/**
+ * Initialise l'identité commune des embeds avec l'avatar actuel du bot.
+ * Le nom reste fixe afin de préserver la marque, même si le compte Discord
+ * est renommé temporairement.
+ */
+export function configureKeplerEmbedIdentity(user: User): void {
+    keplerAuthorIconURL = user.displayAvatarURL({ forceStatic: true });
+}
+
 export function createKeplerEmbed(tone: KeplerTone = 'primary'): EmbedBuilder {
     return new EmbedBuilder()
         .setColor(KEPLER_COLORS[tone])
+        .setAuthor({
+            name: KEPLER_AUTHOR_NAME,
+            ...(keplerAuthorIconURL ? { iconURL: keplerAuthorIconURL } : {})
+        })
         .setTimestamp();
 }
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "codename": "Kepler",
-  "releaseDate": "2026-07-30",
-  "changelog": "Kepler 1.0.0 - Première version stable : XP, tickets, invitations, auto-modération et configuration centralisée."
+  "releaseDate": "2026-07-31",
+  "changelog": "Kepler 1.0.1 - Correction de la synchronisation et de l'affichage des invitations existantes."
 }


### PR DESCRIPTION
## Résumé

- corrige le classement et les statistiques lorsque des invitations existaient avant l’activation du suivi ;
- resynchronise les invitations Discord avant `/invitations` et évite le double comptage ;
- harmonise l’auteur des embeds Kepler sans écraser les footers informatifs ;
- prépare la version, le changelog détaillé et l’annonce Discord 1.0.1.

## Cause

Les invitations existantes étaient bien synchronisées en base, mais les commandes lisaient uniquement les arrivées observées après l’activation du module. Le classement pouvait donc rester vide.

## Impact

Les invitations actives, même inutilisées, apparaissent désormais. Les compteurs distinguent les utilisations Discord des arrivées et départs suivis.

## Validation

- `version.json` validé par parsing JSON ;
- diff de release vérifié sans erreur de whitespace ;
- type-check Deno non exécuté : `deno` n’est pas installé dans l’environnement local ;
- test Discord requis sur un serveur où Kepler possède la permission **Gérer le serveur**.