### PR TITLE
Kepler 1.1.0 — AutoMod, Components V2 et statistiques

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ---
 
+## [1.1.0] - 2026-08-07 (Stable)
+
+### 🎯 Points clés
+- **AutoMod enrichi** avec observation, filtres, seuils, exemptions et actions par règle
+- **Centre `/settings` modernisé** et migré vers Discord Components V2
+- **Statistiques serveur étoffées**, dont la courbe des arrivées et départs
+- **XP plus dynamique** avec cooldown par défaut de 5 secondes et interfaces V2
+- **Invitations modernisées** et classements XP/invitations paginés
+
+👉 [Voir les notes de version détaillées](changelogs/v1.1.0.md)
+
+### ✨ Ajouté
+- Mode observation et protection anti-raid pour l'AutoMod
+- Domaines et mots interdits personnalisables
+- Seuils et sanctions progressives configurables
+- Suivi quotidien des arrivées et départs
+- Navigation directe vers une page des classements XP et invitations
+- Timestamps relatifs dans les interfaces XP
+
+### 🔧 Modifié
+- Réorganisation complète des menus `/settings`
+- Migration de `/settings`, `/xp` et `/invitations` vers Components V2
+- Nouvelle barre de progression XP monospace
+- Graphiques clarifiés avec couleurs, légendes, dates et libellés distincts
+- Discord.js mis à niveau vers la version 14.23.2
+
+### 🐛 Corrigé
+- Sections V2 invalides sur les serveurs dépourvus d'icône
+- Chevauchements de dates et séries trop proches dans les graphiques
+- Rendu des emojis dans les images du conteneur Docker
+- Mentions silencieuses dans les classements Components V2
+
+### 📚 Documentation
+- Documentation AutoMod et graphiques mise à jour
+- Nouvelle roadmap publique jusqu'à Kepler 2.0
+- Procédure de publication et notes Discord pour la V1.1
+
+---
+
 ## [1.0.1] - 2026-07-31 (Stable)
 
 ### 🎯 Points clés

--- a/DISCORD_RELEASE_1.1.0.md
+++ b/DISCORD_RELEASE_1.1.0.md
@@ -1,0 +1,38 @@
+# 🚀 Kepler 1.1 est disponible
+
+Cette mise à jour fait de Kepler un centre de contrôle plus clair, plus réactif
+et mieux adapté à la gestion quotidienne d'un serveur.
+
+🛡️ **Auto-modération renforcée**
+
+Mode observation, filtres personnalisés, seuils, exemptions, sanctions
+progressives et actions différentes selon la règle : l'AutoMod devient beaucoup
+plus précis sans perdre en lisibilité.
+
+⚙️ **Nouveau centre de configuration**
+
+Le panneau `/settings` a été réorganisé et entièrement modernisé avec Discord
+Components V2. Les réglages sont regroupés par thème avec des menus plus courts
+et une navigation cohérente.
+
+📊 **Statistiques plus utiles**
+
+Les graphiques ont été clarifiés et une nouvelle courbe permet de suivre les
+arrivées et départs du serveur. Les statistiques serveur sont maintenant
+publiques et les emojis sont mieux pris en charge.
+
+✨ **Expérience modernisée**
+
+Les profils, classements et annonces XP passent en Components V2. La progression
+est plus lisible et les nouvelles configurations utilisent un cooldown de cinq
+secondes par défaut.
+
+🔗 **Invitations et classements paginés**
+
+Les commandes d'invitations adoptent elles aussi Components V2. Les classements
+XP et invitations disposent de flèches et d'un accès direct à une page.
+
+Merci à toutes les personnes ayant participé aux tests et partagé leurs retours.
+
+**Version :** `1.1.0` · **Type :** Fonctionnalités · **Canal :** Stable
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV FONTCONFIG_FILE=/etc/fonts/fonts.conf
 ENV FONTCONFIG_PATH=/etc/fonts
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends fontconfig fonts-dejavu-core \
+    && apt-get install -y --no-install-recommends fontconfig fonts-dejavu-core fonts-noto-color-emoji \
     && rm -rf /var/lib/apt/lists/* \
     && fc-cache -f
 

--- a/README.md
+++ b/README.md
@@ -1,149 +1,160 @@
-# Kepler - Votre compagnon Discord polyvalent 🚀
+# Kepler — Centre de contrôle Discord 🚀
 
-**WARN : Bot actuellement en beta. Des instabilités et des redémarrages intempestifs sont à prévoir !**
+> **Beta publique :** Kepler est en développement actif. Des changements
+> d'interface et des interruptions ponctuelles peuvent encore survenir.
 
-Kepler est un bot Discord polyvalent en **développement actif**, conçu pour enrichir vos serveurs avec un système de modération avancé, des outils d'administration, la gestion d'anniversaires, et une variété de commandes fun. Écrit en TypeScript avec Deno et utilisant Supabase comme base de données, Kepler offre des performances optimales et une fiabilité accrue.
+Kepler est un bot Discord polyvalent conçu pour administrer, automatiser et
+analyser des communautés. Il réunit les outils courants d'un bot tout-en-un et
+des fonctions de gestion plus spécialisées dans une interface centralisée.
 
-## 🌟 Points Forts
+Version actuelle : **1.1.0**
 
-- **🛡️ Modération Professionnelle** : Système complet avec sanctions numérotées et logs automatiques
-- **🎂 Gestion d'Anniversaires** : Notifications automatiques et configuration flexible  
-- **⚙️ Administration Avancée** : Configuration granulaire et outils d'administration
-- **🎮 Divertissement** : Large gamme de jeux et commandes interactives
-- **🔧 TypeScript + Deno** : Code moderne, performant et sécurisé
+## Points forts
 
----
+- 🛡️ Modération complète et auto-modération configurable.
+- ⚙️ Centre de configuration interactif avec Discord Components V2.
+- 📊 Statistiques serveur et graphiques historiques.
+- ✨ Expérience, niveaux, récompenses et boosts.
+- 🔗 Suivi des invitations et statistiques d'arrivée.
+- 🎫 Tickets privés avec cycle de vie et archives.
+- 🎂 Anniversaires, rappels, jeux et outils communautaires.
+- 🔒 Isolation des données par serveur et contrôles de permissions renforcés.
 
-## 🚀 Fonctionnalités
+## Fonctionnalités
 
-### 🛡️ Système de Modération Avancé
-- **Commandes de base** : `/ban`, `/unban`, `/kick`, `/mute`, `/unmute`, `/timeout`, `/untimeout`
-- **Système d'avertissements** : `/warn`, `/warnings`
-- **Gestion des sanctions** : Numérotation automatique, historique complet avec `/modinfo`
-- **Gestion personnalisée** : `/sanctions voir` et `/sanctions supprimer` pour gérer les historiques
-- **Système de mute hybride** : Timeout Discord (≤28j) ou rôles personnalisés (>28j)
-- **Configuration flexible** : panneau centralisé `/settings`
-- **Logs automatiques** : suivi complet configurable depuis `/settings`
-- **Auto-modération intelligente** : anti-liens, invitations, spam, doublons, majuscules et mentions massives
-- **Expirations automatiques** : Débannissement et démute automatiques
-- **Audit serveur** : `/audit` pour vérifier la configuration des canaux et rôles
+### Modération et sécurité
 
-### 📌 Commandes Utilitaires
-- **Informations serveur** : `/serverinfo`, `/channelinfo`, `/roleinfo`, `/rolelist`
-- **Informations utilisateur** : `/userinfo`
-- **Outils pratiques** : `/genpass`, `/minecraft-uuid`
-- **Système de rappels** : `/reminder`, `/reminders` pour ne rien oublier
+- `/ban`, `/unban`, `/kick`, `/mute`, `/unmute`, `/timeout` et `/untimeout`.
+- Avertissements, historique des sanctions et consultation avec `/modinfo`.
+- Mute hybride : timeout Discord ou rôle dédié.
+- AutoMod contre les liens, invitations, rafales, doublons, majuscules,
+  mentions, mots interdits et raids.
+- Mode observation, seuils, exemptions et sanctions propres à chaque règle.
+- Journaux et archives configurables.
+- Signalement d'un message ou d'un membre à l'équipe de modération.
 
-### 🎂 Système d'Anniversaires
-- **Gestion complète** : Ajout, modification, suppression d'anniversaires
-- **Notifications automatiques** : Souhaits d'anniversaire dans un canal dédié
-- **Configuration flexible** : Canal personnalisable par serveur
+### Configuration
 
-### 🎉 Commandes Fun & Jeux
-- **Jeux classiques** : `/coinflip`, `/chifoumi`, `/8ball`
-- **Jeux avancés** : `/puissance4`, `/golem`
-- **Jeu de comptage** : `/count` pour un mini-jeu collaboratif
-- **Divertissement** : `/blague`, `/meme`
+- Panneau `/settings` réservé aux administrateurs.
+- Navigation par domaines : sécurité, communauté et gestion du serveur.
+- Interfaces Discord Components V2.
+- Configuration des logs, tickets, anniversaires, XP, invitations, fuseau
+  horaire, signalements et modération.
+- Accès optionnel au dashboard web.
 
-### ⚙️ Administration & Configuration
-- **Configuration centralisée** : logs, anniversaires, mute, modération, tickets, XP et invitations via `/settings`
-- **Annonces** : `/annonce` pour communiquer avec votre communauté
-- **Audit serveur** : `/audit` pour vérifier la configuration complète
-- **Gestion des anniversaires** : `/birthday` pour ajouter/modifier/supprimer des anniversaires
-- **Système de permissions** avancé pour une administration sécurisée
+### Expérience
 
----
+- Profils XP par serveur et classement paginé.
+- Gain aléatoire de 15 à 25 XP par message admissible.
+- Cooldown configurable, fixé à 5 secondes pour les nouvelles configurations.
+- Récompenses de niveau et annonces automatiques.
+- Boosts temporaires et boosts par rôle.
+- Exclusions par salon et rôle.
+- Journaux dédiés et interfaces Components V2.
 
-## 🛠️ Roadmap
+### Invitations
 
-### ✅ Alpha (Terminé)
-- **Passage en TypeScript** : ✅ Refonte complète du bot en TypeScript
-- **Système de modération avancé** : ✅ Commandes complètes avec sanctions numérotées
-- **Base de données Supabase** : ✅ Migration vers PostgreSQL
-- **Système d'anniversaires** : ✅ Gestion complète des anniversaires
-- **Logs de modération** : ✅ Système de journalisation configurable
+- Synchronisation des invitations Discord existantes.
+- Attribution des arrivées à leur inviteur.
+- Classement paginé et statistiques individuelles.
+- Annonces d'arrivée personnalisables.
+- Suivi des créations, suppressions et utilisations de liens.
+- Distinction entre arrivées suivies, membres présents et départs.
 
-### 🔄 Beta 1.3 (En cours - Janvier 2026)
-- **Audit serveur avancé** : ✅ Vérification automatique de la configuration
-- **Gestion personnalisée des sanctions** : ✅ Suppression et visualisation des sanctions
-- **Jeu de comptage collaboratif** : ✅ Mini-jeu `/count` pour les serveurs
-- **Timeout Discord** : ✅ Support complet de la nouvelle fonctionnalité de timeout Discord
-- **Historique détaillé** : ✅ `/modinfo` avec suivi complet des sanctions
-- **Optimisations performances** : 🔧 Amélioration de la vitesse et stabilité
-- **Nouvelles commandes fun** : 🔧 Extension du catalogue de jeux
-- **Gestion des événements serveur** : 🔧 Logs enrichis pour tous les événements
+### Statistiques
 
-### 🚀 Release (Janvier/Février 2026)
-- **Lancement officiel** de Kepler v1.0
-- **Site web dédié** avec documentation complète
-- **Système de niveaux** : XP et rangs pour les utilisateurs
+- Résumé de l'activité du serveur.
+- Courbes des messages, commandes, arrivées et départs.
+- Classements des salons, membres et commandes les plus actifs.
+- Périodes de 7 à 360 jours ou depuis toujours.
+- Graphiques WebP mis en cache et adaptés à l'identité Kepler.
 
----
+### Tickets et communauté
 
-## 🎯 Commandes Principales
+- Panneau de tickets personnalisable.
+- Salons privés, rôle support, fermeture, réouverture et archivage.
+- Export texte des conversations.
+- Gestion et annonces d'anniversaires.
+- Rappels personnels et fuseaux horaires IANA.
+- Giveaways, quiz et jeux interactifs.
 
-### Modération
-```
-/ban <utilisateur> [durée] [raison]     # Bannir un utilisateur
-/unban <user_id> [raison]               # Débannir un utilisateur
-/kick <utilisateur> [raison]            # Expulser un utilisateur  
-/mute <utilisateur> <durée> [raison]    # Rendre muet un utilisateur
-/unmute <utilisateur> [raison]          # Annuler le mute
-/timeout <utilisateur> <durée> [raison] # Timeout Discord
-/untimeout <utilisateur> [raison]       # Retirer le timeout
-/warn <utilisateur> <raison>            # Avertir un utilisateur
-/warnings <utilisateur>                 # Voir les avertissements
-/modinfo <utilisateur>                  # Infos complètes de modération
-/sanctions voir <utilisateur>           # Voir toutes les sanctions
-/sanctions supprimer <numero>           # Supprimer une sanction
-```
+### Vie privée et exploitation
 
-### Administration
-```
-/settings                               # Ouvrir toute la configuration du serveur
-/annonce <message>                      # Faire une annonce
-/audit channel                          # Auditer les canaux configurés
-/audit roles                            # Auditer les rôles configurés
+- Export et suppression des données personnelles avec `/mesdonnees`.
+- RLS Supabase et fonctions sensibles réservées au service backend.
+- Signalement centralisé des erreurs Discord.
+- Déploiement Docker avec Deno et Discord.js.
+
+## Commandes principales
+
+### Administration et modération
+
+```text
+/settings                           Configuration complète du serveur
+/graph                              Statistiques et graphiques serveur
+/audit                              Vérification de la configuration
+/ban, /kick, /mute, /timeout        Sanctions
+/warn, /warnings, /modinfo          Avertissements et historique
+/sanctions                          Gestion des sanctions enregistrées
+/clear                              Suppression filtrée de messages
 ```
 
-### Utilitaires
-```
-/userinfo <utilisateur>                # Informations utilisateur
-/serverinfo                            # Informations serveur
-/channelinfo <canal>                   # Informations canal
-/roleinfo <rôle>                       # Informations rôle
-/rolelist                              # Liste des rôles du serveur
-/reminder <durée> <message>            # Créer un rappel personnel
-/reminders                             # Voir vos rappels
-/invitations classement               # Classement des inviteurs
-/invitations membre [utilisateur]      # Statistiques d'invitations
-/birthday add <date> [notes]           # Ajouter un anniversaire
-/birthday remove <utilisateur>         # Retirer un anniversaire
-/birthday list                         # Voir tous les anniversaires
-/genpass [longueur]                    # Générer un mot de passe
-/minecraft-uuid <pseudo>               # Obtenir l'UUID Minecraft
+### Communauté et utilitaires
+
+```text
+/xp profil [membre]                 Profil et progression XP
+/xp classement                      Classement XP paginé
+/invitations membre [utilisateur]   Statistiques d'invitations
+/invitations classement             Classement des inviteurs
+/birthday                           Gestion des anniversaires
+/reminder, /reminders               Rappels personnels
+/userinfo, /serverinfo              Informations Discord
+/channelinfo, /roleinfo, /rolelist  Informations du serveur
+/report                             Signalement à la modération
 ```
 
+Utilisez `/help` pour consulter les commandes disponibles sur votre instance.
+
+## Roadmap
+
+La roadmap publique couvre les versions V1.2 à V1.5 prévues entre août et
+octobre 2026, les éventuelles versions intermédiaires et l'objectif Kepler 2.0
+avec sharding en fin d'année.
+
+➡️ [Consulter la roadmap détaillée](ROADMAP.md)
+
+## Installation
+
+Ajoutez Kepler à votre serveur depuis
+[l'App Directory Discord](https://discord.com/application-directory/1208555753502412868).
+
+Le bot doit disposer des permissions nécessaires aux modules activés. Le suivi
+des invitations nécessite notamment **Gérer le serveur**.
+
+## Technologies
+
+- **Runtime :** Deno et TypeScript.
+- **API Discord :** Discord.js 14.23.2.
+- **Base de données :** Supabase/PostgreSQL.
+- **Images :** Sharp, SVG et WebP.
+- **Déploiement :** Docker et Dokploy.
+
+## Documentation
+
+- [Architecture](docs/ARCHITECTURE.md)
+- [Auto-modération](docs/AUTOMOD.md)
+- [Graphiques](docs/GRAPH_COMMAND.md)
+- [Invitations](docs/INVITE-MANAGER.md)
+- [Système XP](docs/XP-SYSTEM.md)
+- [Direction artistique](docs/DIRECTION-ARTISTIQUE.md)
+- [Changelog](CHANGELOG.md)
+- [Procédure de release](RELEASE.md)
+
+## Contribution et retours
+
+Les retours, propositions et rapports de bugs sont les bienvenus sur le
+[serveur Discord](https://discord.gg/GbavRtUwad) ou dans les issues GitHub.
+
 ---
 
-## 🤝 Contribution
-Votre avis compte ! Partagez vos retours, idées ou rapports de bugs en rejoignant notre serveur [Discord](https://discord.gg/GbavRtUwad) ou en créant une issue sur GitHub.
-
----
-
-## 📥 Installation
-Ajoutez Kepler à votre serveur en suivant [ce lien](https://discord.com/application-directory/1208555753502412868).
-
----
-
-## 🔧 Technologies
-
-- **Runtime** : Deno (TypeScript natif)
-- **Framework** : Discord.js v14
-- **Base de données** : Supabase (PostgreSQL)
-- **Déploiement** : Docker
-- **CI/CD** : GitHub Actions
-
----
-
-*Kepler est développé avec ❤️ pour la communauté Discord française*
+Kepler est développé avec ❤️ pour la communauté Discord française.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,29 +1,44 @@
-# Release Kepler 1.0.1
+# Release Kepler 1.1.0
 
-Ce document décrit la promotion de la branche `v1.0.1` vers la production.
+Ce document décrit la promotion de la branche `v1.1` vers la production.
 Dokploy déploie l'environnement de développement depuis `main` et la production
 depuis un tag Git sélectionné manuellement.
 
 ## Avant le merge
 
-- [x] `version.json` annonce `1.0.1` et le canal stable
-- [x] `CHANGELOG.md` et `changelogs/v1.0.1.md` sont à jour
-- [x] La note Discord est prête dans `DISCORD_RELEASE_1.0.1.md`
-- [x] Aucune migration Supabase supplémentaire n'est nécessaire
-- [ ] Le type-check Deno passe
-- [ ] L'image Docker se construit
-- [ ] La branche de développement a été testée avec les services externes
-- [ ] `/invitations classement` récupère les invitations Discord existantes
-- [ ] La PR `v1.0.1` vers `main` est approuvée et fusionnée
+- [x] `version.json` annonce `1.1.0` et la date de publication.
+- [x] `README.md`, `ROADMAP.md` et `CHANGELOG.md` sont à jour.
+- [x] Les notes détaillées sont prêtes dans `changelogs/v1.1.0.md`.
+- [x] La note Discord est prête dans `DISCORD_RELEASE_1.1.0.md`.
+- [ ] La checklist de qualification V1.1 est validée sur le bot de test.
+- [ ] Les trois migrations Supabase V1.1 sont appliquées en préproduction.
+- [ ] Le type-check Deno passe ou les erreurs historiques sont explicitement
+  acceptées.
+- [ ] L'image Docker se construit avec Noto Color Emoji.
+- [ ] La branche a été testée avec Discord et Supabase.
+- [ ] La PR `v1.1` vers `main` est approuvée et fusionnée.
 
 ## Supabase PROD
 
-Aucune nouvelle migration n'est requise depuis la version 1.0.0. Vérifier que
-Kepler utilise toujours la clé serveur `SUPABASE_SERVICE_ROLE_KEY`.
+Sauvegarder la base puis appliquer les migrations dans cet ordre :
+
+1. `20260804_extend_automod_v1_1.sql`
+2. `20260805_add_member_flow_stats.sql`
+3. `20260806_set_default_xp_cooldown.sql`
+
+Contrôler ensuite :
+
+- les nouveaux réglages AutoMod sur un serveur pilote ;
+- la fonction d'agrégation des arrivées et départs ;
+- la valeur par défaut de `guild_xp_settings.cooldown_seconds` ;
+- la conservation du cooldown des configurations XP existantes.
+
+Les fonctions sensibles doivent rester accessibles uniquement au rôle
+`service_role`.
 
 ## Variables Dokploy PROD
 
-Reprendre `.env.example` et vérifier au minimum :
+Reprendre la configuration de production et vérifier au minimum :
 
 ```env
 TOKEN=
@@ -37,6 +52,20 @@ DISCORD_ERROR_REPORTER_TEST=false
 Variables optionnelles : `PASTEBIN_API_KEY`, `ERROR_CHANNEL_ID` et
 `DASHBOARD_URL`. Ne pas activer `DISCORD_ERROR_REPORTER_TEST` en production.
 
+## Vérifications Discord
+
+Sur un serveur pilote :
+
+1. Vérifier les permissions du bot, notamment **Gérer le serveur**, **Gérer les
+   messages** et la hiérarchie des rôles.
+2. Ouvrir `/settings` et parcourir chaque catégorie Components V2.
+3. Activer l'AutoMod en mode observation avant toute sanction réelle.
+4. Générer chaque type de graphique, dont les arrivées et départs.
+5. Tester `/xp profil`, `/xp classement` et la pagination.
+6. Tester `/invitations membre`, `/invitations classement` et la pagination.
+7. Vérifier une annonce de niveau et un journal XP.
+8. Contrôler le rendu sur Discord desktop et mobile.
+
 ## Tag et release GitHub
 
 Le tag doit être créé uniquement sur le commit de merge présent dans `main` :
@@ -44,25 +73,28 @@ Le tag doit être créé uniquement sur le commit de merge présent dans `main` 
 ```bash
 git switch main
 git pull --ff-only origin main
-git tag -a v1.0.1 -m "Kepler 1.0.1"
-git push origin v1.0.1
+git tag -a v1.1.0 -m "Kepler 1.1.0"
+git push origin v1.1.0
 ```
 
-Créer ensuite la release GitHub `v1.0.1` en copiant le contenu de
-`changelogs/v1.0.1.md`. Ne pas marquer la release comme pre-release.
+Créer ensuite la release GitHub `v1.1.0` en copiant le contenu de
+`changelogs/v1.1.0.md`. Ne pas marquer la release comme pre-release.
 
 ## Déploiement Dokploy
 
 1. Ouvrir le service Kepler PROD.
-2. Sélectionner le tag `v1.0.1`.
+2. Sélectionner le tag `v1.1.0`.
 3. Construire et déployer l'image.
-4. Contrôler les logs de démarrage et la connexion Discord.
-5. Vérifier `/help`, `/settings` et `/invitations` sur un serveur pilote.
-6. Vérifier le classement avec une invitation créée avant le déploiement.
-7. Publier `DISCORD_RELEASE_1.0.1.md` après validation.
+4. Contrôler les logs de démarrage, Discord et Supabase.
+5. Exécuter la vérification rapide sur le serveur pilote.
+6. Surveiller les erreurs AutoMod, XP et invitations.
+7. Publier `DISCORD_RELEASE_1.1.0.md` après validation.
 
 ## Retour arrière
 
-En cas d'incident, redéployer le tag stable `v1.0.0` dans Dokploy. La version
-1.0.1 n'ajoute aucune migration et ne nécessite aucun retour arrière de base de
-données.
+En cas d'incident applicatif, redéployer le tag stable `v1.0.1` dans Dokploy.
+
+Les migrations V1.1 ne doivent pas être supprimées automatiquement pendant le
+rollback : elles ajoutent des colonnes et fonctions compatibles avec l'ancienne
+version. Restaurer une sauvegarde Supabase uniquement si une migration a échoué
+ou si son impact sur les données a été confirmé.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,120 @@
+# Roadmap de Kepler
+
+Cette roadmap présente la direction prévue pour Kepler après la version 1.1.
+Les périodes annoncées sont indicatives : le contenu et le nombre de versions
+intermédiaires pourront évoluer selon les retours, les besoins techniques et le
+niveau de qualité attendu avant Kepler 2.0.
+
+## Vision
+
+Kepler a vocation à devenir un centre de contrôle polyvalent pour administrer,
+automatiser et analyser des communautés Discord. Le bot doit rester un couteau
+suisse accessible tout en proposant des outils de gestion spécialisés rarement
+réunis dans une même application : audit de configuration, santé du serveur,
+mode incident, workflows administratifs et gestion de réseaux de serveurs.
+
+## Principes directeurs
+
+- Construire des modules complets plutôt qu'une accumulation de commandes
+  isolées.
+- Centraliser les réglages et conserver une navigation cohérente.
+- Migrer progressivement les interfaces vers Discord Components V2.
+- Rendre chaque module observable, configurable et sûr par défaut.
+- Préparer l'architecture distribuée sans ralentir les versions 1.x.
+
+À partir de la V1.2, tout module fonctionnellement modifié doit migrer vers
+Components V2. Chaque version inclura également un lot de modernisation des
+interfaces existantes. L'objectif est de ne conserver aucun embed classique à
+l'approche de Kepler 2.0.
+
+## V1.1 — Modération, statistiques et expérience
+
+**Période visée : août 2026 — qualification en cours**
+
+- Auto-modération enrichie : observation, filtres personnalisés, seuils,
+  exemptions et sanctions par règle.
+- Centre de configuration `/settings` réorganisé et migré vers Components V2.
+- Graphiques serveur plus lisibles et suivi des arrivées et départs.
+- Expérience serveur améliorée : cooldown, boosts, récompenses, journaux et
+  interfaces V2.
+- Commandes d'invitations modernisées et classements paginés.
+- Navigation directe par numéro de page pour les classements.
+- Meilleure prise en charge des emojis dans les graphiques.
+
+## V1.2 — Communauté et identité serveur
+
+**Période visée : fin août 2026**
+
+- Messages d'accueil et de départ avancés.
+- Messages privés d'accueil.
+- Rôles automatiques et rôles interactifs.
+- Amélioration des anniversaires et des profils communautaires.
+- Prévisualisation des messages avant publication.
+- Statistiques de rétention et qualité des sources d'invitation.
+- Migration V2 des anniversaires, jeux communautaires et commandes
+  d'information générales.
+- Première version du kit d'interface partagé de Kepler.
+
+## V1.3 — Administration intelligente
+
+**Période visée : septembre 2026**
+
+- Audit global de la configuration.
+- Détection des salons, rôles et références devenus invalides.
+- Contrôle des permissions et de la hiérarchie des rôles.
+- Détection des accès sensibles ou incohérents.
+- Score de santé du serveur et recommandations exploitables.
+- Sauvegarde, restauration et export de configuration.
+- Historique des changements administratifs.
+- Assistant de nettoyage des configurations obsolètes.
+- Migration V2 des commandes d'administration et des journaux.
+
+## V1.4 — Automatisation et workflows
+
+**Période visée : fin septembre ou début octobre 2026**
+
+- Messages récurrents et rappels de bump.
+- Messages persistants et publications planifiées.
+- Attribution temporaire de rôles.
+- Ouverture et fermeture programmées de salons.
+- Déclencheurs et actions personnalisables.
+- Workflows liés aux arrivées, départs, niveaux et incidents.
+- Historique et reprise des automatisations après redémarrage.
+- Mode incident automatisé.
+- Première mise à jour majeure du dashboard pour gérer les automatisations.
+
+## V1.5 — Exploitation et préparation au changement d'échelle
+
+**Période visée : octobre 2026**
+
+- Tableau de santé du bot par serveur.
+- Métriques de performance et suivi des erreurs par fonctionnalité.
+- Statistiques opérationnelles avancées.
+- Analyse de l'activité de modération, des tickets et des signalements.
+- Amélioration des caches et des tâches planifiées.
+- Deuxième phase du dashboard et premières fonctions multi-serveurs.
+- Suppression des derniers embeds classiques.
+- Préparation des managers, caches et collecteurs au sharding.
+
+## Versions intermédiaires éventuelles
+
+**Période possible : novembre 2026**
+
+Kepler pourra recevoir des versions V1.6, V1.7 ou correctives avant la V2.0.
+Elles permettront d'intégrer les retours utilisateurs, de stabiliser le
+dashboard, d'expérimenter de nouveaux outils spécialisés ou d'ajouter des
+prérequis techniques au sharding.
+
+## Kepler 2.0 — Architecture distribuée
+
+**Objectif indicatif : fin 2026**
+
+- Sharding Discord.
+- Exécution sur plusieurs processus ou instances.
+- Coordination distribuée des caches et tâches planifiées.
+- Supervision centralisée et reprise après incident.
+- Dashboard multi-serveurs complet.
+- Gestion de réseaux de serveurs et politiques partagées.
+- Modèles de configuration réutilisables.
+- Architecture modulaire durable pour la montée en charge.
+

--- a/changelogs/README.md
+++ b/changelogs/README.md
@@ -15,7 +15,11 @@ Chaque version a son propre fichier markdown avec :
 ## 🗂️ Index des versions
 
 ### Stable
-- [v1.0.1](v1.0.1.md) - 31 juillet 2026 - **Correctif 1.0.1** ✅ Actuelle
+- [v1.1.0](v1.1.0.md) - 7 août 2026 - **Version 1.1 actuelle** ✅
+  - AutoMod enrichi et centre `/settings` en Components V2
+  - Nouveaux graphiques serveur et suivi des mouvements de membres
+  - XP et invitations modernisés avec classements paginés
+- [v1.0.1](v1.0.1.md) - 31 juillet 2026 - **Correctif 1.0.1**
   - Récupération des invitations déjà présentes
   - Classement et statistiques corrigés sans double comptage
   - Identité visuelle des embeds harmonisée

--- a/changelogs/v1.1.0.md
+++ b/changelogs/v1.1.0.md
@@ -1,0 +1,75 @@
+# Kepler 1.1.0
+
+Date de sortie : 7 août 2026
+
+Canal : stable
+
+Kepler 1.1 renforce la modération automatique, modernise le centre de
+configuration et enrichit les outils d'analyse, d'expérience et d'invitations.
+
+## Auto-modération
+
+- Mode observation pour évaluer les règles sans sanctionner les membres.
+- Filtres personnalisables pour les domaines et mots interdits.
+- Seuils configurables pour le spam, les doublons, les majuscules et les
+  mentions.
+- Exemptions par salon, catégorie et rôle.
+- Action générale, progression des sanctions et actions spécifiques par règle.
+- Protection anti-raid et suivi des exécutions AutoMod de Discord.
+- Navigation dédiée dans `/settings` et documentation mise à jour.
+
+## Centre de configuration
+
+- Réorganisation des réglages par domaines fonctionnels.
+- Regroupement de toute la modération au même endroit.
+- Migration complète du panneau `/settings` vers Components V2.
+- Résumés plus courts, menus par catégorie et navigation homogène.
+- Conservation d'un panneau privé réservé à son administrateur.
+
+## Statistiques et graphiques
+
+- Panneau `/graph` public pour les statistiques du serveur.
+- Courbe des arrivées et départs.
+- Libellés, couleurs, légendes et périodes clarifiés.
+- Réduction des chevauchements de textes et meilleure sélection des dates.
+- Prise en charge des emojis dans les images grâce à une police dédiée.
+- Agrégation quotidienne des mouvements de membres en base de données.
+
+## Expérience
+
+- Cooldown XP par défaut ramené à 5 secondes pour les nouvelles
+  configurations ; les valeurs existantes restent inchangées.
+- Profils, classements, annonces de niveau et journaux migrés vers Components
+  V2.
+- Nouvelle barre de progression monospace sur dix segments.
+- Affichage du demandeur et d'un timestamp relatif.
+- Classement paginé avec flèches et accès direct par numéro de page.
+- Les mentions affichées dans le classement ne déclenchent aucune notification.
+
+## Invitations
+
+- Commandes `/invitations classement` et `/invitations membre` migrées vers
+  Components V2.
+- Classement paginé avec navigation directe par numéro de page.
+- Statistiques individuelles rendues plus lisibles.
+- Synchronisation des invitations conservée avant chaque consultation.
+
+## Dépendances et exploitation
+
+- Discord.js aligné sur la version `14.23.2` pour Components V2.
+- Ajout de Noto Color Emoji à l'image Docker.
+- Nouvelles migrations Supabase pour l'AutoMod, les mouvements de membres et le
+  cooldown XP par défaut.
+
+## Mise à niveau depuis 1.0.1
+
+1. Sauvegarder la base de données de production.
+2. Appliquer, dans l'ordre, les migrations du 4, 5 et 6 août 2026.
+3. Déployer Kepler 1.1.0 avec Discord.js 14.23.2.
+4. Vérifier `/settings`, `/graph`, `/xp` et `/invitations` sur un serveur pilote.
+5. Qualifier l'AutoMod en mode observation avant d'activer les sanctions.
+
+Les migrations ajoutent des colonnes et fonctions sans réécrire les réglages
+existants. Le nouveau cooldown de 5 secondes ne remplace pas les valeurs déjà
+enregistrées.
+

--- a/commands/README.md
+++ b/commands/README.md
@@ -24,7 +24,7 @@ Commandes réservées aux administrateurs du serveur ou à l'owner du bot.
 | `/annonce` | Envoyer une annonce dans un canal | Admin |
 | `/audit` | Consulter les logs d'audit | Admin |
 | `/giveaway` | Créer et gérer des giveaways | Admin |
-| `/graph` | Statistiques d'utilisation du bot | Owner |
+| `/graph` | Statistiques publiques du serveur et graphiques d’évolution | Administrateur |
 | `/settings` | Configurer les modules du serveur | Admin |
 
 ---

--- a/commands/administration/graph.ts
+++ b/commands/administration/graph.ts
@@ -437,7 +437,7 @@ async function handleChannels(interaction: ChatInputCommandInteraction) {
         const channel = interaction.guild!.channels.cache.get(channelStat.channel_id);
         const name = channel ? `#${channel.name}` : 'Canal supprimé';
         chartData.push({
-            label: name.slice(0, 15),
+            label: name,
             value: channelStat.message_count
         });
     }
@@ -490,7 +490,7 @@ async function handleUsers(interaction: ChatInputCommandInteraction) {
         return `${medal} **${user.username}** - ${user.message_count.toLocaleString()} messages`;
     });
     const chartData = resolvedUsers.map(user => ({
-        label: user.username.slice(0, 24),
+        label: user.username,
         value: user.message_count
     }));
 

--- a/commands/administration/graph.ts
+++ b/commands/administration/graph.ts
@@ -17,8 +17,9 @@ import {
     getTotalStats
 } from '../../utils/stats/tracker.ts';
 import { renderBarChart, renderLineChart } from '../../utils/stats/chart.ts';
+import { getMemberFlowStats } from '../../utils/invites/service.ts';
 
-type ServerStatsAction = 'overview' | 'activity' | 'members' | 'channels' | 'users' | 'commands';
+type ServerStatsAction = 'overview' | 'activity' | 'growth' | 'members' | 'channels' | 'users' | 'commands';
 const PANEL_TIMEOUT = 5 * 60 * 1000;
 
 export const data = new SlashCommandBuilder()
@@ -31,7 +32,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     if (!interaction.memberPermissions?.has(PermissionFlagsBits.Administrator)) {
         return void await interaction.reply({ content: KEPLER_MESSAGES.administratorOnly, ephemeral: true });
     }
-    const response = await interaction.reply({ ...serverHome(interaction), ephemeral: true, fetchReply: true });
+    const response = await interaction.reply({ ...serverHome(interaction), fetchReply: true });
     const collector = response.createMessageComponentCollector({ time: PANEL_TIMEOUT });
     collector.on('collect', async component => {
         if (component.user.id !== interaction.user.id) return void await component.reply({ content: KEPLER_MESSAGES.unauthorizedComponent, ephemeral: true });
@@ -78,10 +79,20 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 
 function serverHome(interaction: ChatInputCommandInteraction) {
     const embed = createKeplerEmbed('primary').setTitle(`📊 Statistiques de ${interaction.guild!.name}`)
-        .setDescription('Choisissez une vue, puis la période à analyser.').setThumbnail(interaction.guild!.iconURL({ forceStatic: true }))
-        .setFooter({ text: 'Panneau privé • expiration dans 5 minutes' });
-    const row1 = new ActionRowBuilder<ButtonBuilder>().addComponents(serverButton('overview', 'Vue d’ensemble', '📊'), serverButton('activity', 'Activité', '📈'), serverButton('members', 'Membres', '👥'));
-    const row2 = new ActionRowBuilder<ButtonBuilder>().addComponents(serverButton('channels', 'Canaux', '📺'), serverButton('users', 'Utilisateurs', '👑'), serverButton('commands', 'Commandes', '⚡'));
+        .setDescription('Choisissez une statistique. Les vues historiques proposent ensuite une période.')
+        .setThumbnail(interaction.guild!.iconURL({ forceStatic: true }))
+        .setFooter({ text: 'Statistiques publiques • panneau disponible pendant 5 minutes' });
+    const row1 = new ActionRowBuilder<ButtonBuilder>().addComponents(
+        serverButton('overview', 'Résumé de l’activité', '📊'),
+        serverButton('activity', 'Messages et commandes', '💬'),
+        serverButton('growth', 'Arrivées et départs', '📈'),
+        serverButton('members', 'État actuel', '👥')
+    );
+    const row2 = new ActionRowBuilder<ButtonBuilder>().addComponents(
+        serverButton('channels', 'Salons actifs', '📺'),
+        serverButton('users', 'Membres actifs', '👑'),
+        serverButton('commands', 'Commandes utilisées', '⚡')
+    );
     const controls = new ActionRowBuilder<ButtonBuilder>().addComponents(new ButtonBuilder().setCustomId('graph:home').setEmoji('🔄').setStyle(ButtonStyle.Secondary), new ButtonBuilder().setCustomId('graph:close').setEmoji('✖️').setStyle(ButtonStyle.Secondary));
     return { content: '', embeds: [embed], components: [row1, row2, controls], attachments: [] };
 }
@@ -121,7 +132,7 @@ async function runServerAction(source: ChatInputCommandInteraction, component: a
     await component.editReply({ content: '', attachments: [], components: [], embeds: [createKeplerEmbed('neutral').setTitle('Génération du graphique').setDescription('⏳ Préparation des statistiques…')] });
     const interaction = statsAdapter(source, component, days, limit);
     if (action === 'overview') await handleOverview(interaction); else if (action === 'activity') await handleActivity(interaction);
-    else if (action === 'members') await handleMembers(interaction); else if (action === 'channels') await handleChannels(interaction);
+    else if (action === 'growth') await handleGrowth(interaction); else if (action === 'members') await handleMembers(interaction); else if (action === 'channels') await handleChannels(interaction);
     else if (action === 'users') await handleUsers(interaction); else await handleCommands(interaction);
 }
 
@@ -159,7 +170,7 @@ async function handleOverview(interaction: ChatInputCommandInteraction) {
 
 
     const overviewBuffer = await renderLineChart(
-        `Activité de ${interaction.guild!.name}`,
+        `Messages et commandes · ${interaction.guild!.name}`,
         periodLabel,
         dailyStats.map(d => formatChartDate(d.date)),
         [
@@ -184,7 +195,7 @@ async function handleOverview(interaction: ChatInputCommandInteraction) {
 
     const embed = createKeplerEmbed()
         .setColor(KEPLER_COLORS.primary)
-        .setTitle(`📊 Vue d'ensemble - ${guild.name}`)
+        .setTitle(`📊 Résumé de l’activité · ${guild.name}`)
         .setThumbnail(guild.iconURL() || null)
         .setDescription(`Statistiques sur **${periodLabel}**`)
         .addFields(
@@ -243,7 +254,7 @@ async function handleActivity(interaction: ChatInputCommandInteraction) {
         : null;
 
     const activityBuffer = await renderLineChart(
-        'Activité du serveur',
+        'Messages et commandes',
         periodLabel,
         dailyStats.map(d => formatChartDate(d.date)),
         [
@@ -256,8 +267,8 @@ async function handleActivity(interaction: ChatInputCommandInteraction) {
 
     const embed = createKeplerEmbed()
         .setColor(KEPLER_COLORS.primary)
-        .setTitle(`📈 Activité du serveur`)
-        .setDescription(`Période: **${periodLabel}**`)
+        .setTitle('💬 Messages et commandes')
+        .setDescription(`Activité enregistrée sur **${periodLabel}**.`)
         .addFields(
             {
                 name: '💬 Messages',
@@ -278,8 +289,8 @@ async function handleActivity(interaction: ChatInputCommandInteraction) {
             },
             { name: '\u200b', value: '\u200b', inline: true },
             {
-                name: '📊 Tendance des messages',
-                value: 'Graphique détaillé ci-dessous.',
+                name: 'Lecture du graphique',
+                value: 'Chaque point représente le nombre de messages et de commandes enregistrés pendant la journée.',
                 inline: false
             }
         )
@@ -288,6 +299,46 @@ async function handleActivity(interaction: ChatInputCommandInteraction) {
         .setTimestamp();
 
     await interaction.editReply({ embeds: [embed], files: [activityAttachment] });
+}
+
+async function handleGrowth(interaction: ChatInputCommandInteraction) {
+    const days = resolveStatsDays(interaction, 30);
+    const periodLabel = formatStatsPeriod(days);
+    const flow = await getMemberFlowStats(interaction.guildId!, days);
+    const totalJoins = flow.reduce((total, day) => total + day.joins, 0);
+    const totalLeaves = flow.reduce((total, day) => total + day.leaves, 0);
+    const netGrowth = totalJoins - totalLeaves;
+    const chart = await renderLineChart(
+        'Arrivées et départs',
+        periodLabel,
+        flow.map(day => formatChartDate(day.date)),
+        [
+            { label: 'Arrivées', color: KEPLER_CHART_COLORS.joins, values: flow.map(day => day.joins) },
+            { label: 'Départs', color: KEPLER_CHART_COLORS.leaves, values: flow.map(day => day.leaves) }
+        ]
+    );
+    const attachment = new AttachmentBuilder(chart, { name: 'server-member-flow.webp' });
+    const sign = netGrowth > 0 ? '+' : '';
+    const embed = createKeplerEmbed('primary')
+        .setTitle('📈 Arrivées et départs')
+        .setDescription(
+            `Mouvements enregistrés sur **${periodLabel}**. ` +
+            'Les départs sont comptés uniquement pour les membres dont l’arrivée a été suivie par Kepler.'
+        )
+        .addFields(
+            { name: '📥 Arrivées', value: totalJoins.toLocaleString('fr-FR'), inline: true },
+            { name: '📤 Départs', value: totalLeaves.toLocaleString('fr-FR'), inline: true },
+            { name: 'Solde net', value: `**${sign}${netGrowth.toLocaleString('fr-FR')}** membre(s)`, inline: true },
+            {
+                name: 'Lecture du graphique',
+                value: 'La courbe verte représente les arrivées quotidiennes ; la rouge représente les départs quotidiens.',
+                inline: false
+            }
+        )
+        .setImage('attachment://server-member-flow.webp')
+        .setFooter({ text: `Demandé par ${interaction.user.username}` })
+        .setTimestamp();
+    await interaction.editReply({ embeds: [embed], files: [attachment] });
 }
 
 async function handleMembers(interaction: ChatInputCommandInteraction) {
@@ -321,7 +372,7 @@ async function handleMembers(interaction: ChatInputCommandInteraction) {
 
     const embed = createKeplerEmbed()
         .setColor(KEPLER_COLORS.accent)
-        .setTitle(`👥 Statistiques des membres`)
+        .setTitle('👥 État actuel des membres')
         .setThumbnail(guild.iconURL() || null)
         .addFields(
             {
@@ -391,16 +442,16 @@ async function handleChannels(interaction: ChatInputCommandInteraction) {
         });
     }
 
-    const channelsBuffer = await renderBarChart('Canaux les plus actifs', periodLabel, chartData, KEPLER_CHART_COLORS.channels);
+    const channelsBuffer = await renderBarChart('Salons avec le plus de messages', periodLabel, chartData, KEPLER_CHART_COLORS.channels);
     const channelsAttachment = new AttachmentBuilder(channelsBuffer, { name: 'server-channels.webp' });
 
     const embed = createKeplerEmbed()
         .setColor(KEPLER_COLORS.danger)
-        .setTitle('📺 Canaux les plus actifs')
-        .setDescription(`Période: **${periodLabel}**`)
+        .setTitle('📺 Salons avec le plus de messages')
+        .setDescription(`Classement selon le nombre de messages envoyés sur **${periodLabel}**.`)
         .addFields({
-            name: '📊 Classement',
-            value: 'Graphique détaillé ci-dessous.',
+            name: 'Mesure utilisée',
+            value: 'Nombre de messages enregistrés dans chaque salon.',
             inline: false
         })
         .setImage('attachment://server-channels.webp')
@@ -443,13 +494,13 @@ async function handleUsers(interaction: ChatInputCommandInteraction) {
         value: user.message_count
     }));
 
-    const usersBuffer = await renderBarChart('Utilisateurs les plus actifs', periodLabel, chartData, KEPLER_CHART_COLORS.users);
+    const usersBuffer = await renderBarChart('Membres avec le plus de messages', periodLabel, chartData, KEPLER_CHART_COLORS.users);
     const usersAttachment = new AttachmentBuilder(usersBuffer, { name: 'server-users.webp' });
 
     const embed = createKeplerEmbed()
         .setColor(KEPLER_COLORS.highlight)
-        .setTitle('👑 Utilisateurs les plus actifs')
-        .setDescription(`Période: **${periodLabel}**\n\n${userLines.join('\n')}`)
+        .setTitle('👑 Membres avec le plus de messages')
+        .setDescription(`Classement sur **${periodLabel}**.\n\n${userLines.join('\n')}`)
         .setImage('attachment://server-users.webp')
         .setFooter({ text: `Demandé par ${interaction.user.username}` })
         .setTimestamp();
@@ -487,7 +538,7 @@ async function handleCommands(interaction: ChatInputCommandInteraction) {
     const embed = createKeplerEmbed()
         .setColor(KEPLER_COLORS.warning)
         .setTitle('⚡ Commandes les plus utilisées')
-        .setDescription(`Période: **${periodLabel}**`)
+        .setDescription(`Nombre d’exécutions sur **${periodLabel}**.`)
         .addFields(
             {
                 name: '📊 Résumé',
@@ -498,8 +549,8 @@ async function handleCommands(interaction: ChatInputCommandInteraction) {
                 inline: false
             },
             {
-                name: '🏆 Top 10',
-                value: 'Graphique détaillé ci-dessous.',
+                name: 'Mesure utilisée',
+                value: 'Nombre d’exécutions réussies ou tentées pour chaque commande.',
                 inline: false
             }
         )

--- a/commands/administration/settings.ts
+++ b/commands/administration/settings.ts
@@ -59,7 +59,9 @@ import {
 } from '../../utils/invites/service.ts';
 import {
     getAutoModSettings,
-    updateAutoModSettings
+    getAutoModStats,
+    updateAutoModSettings,
+    type AutoModEscalationStep
 } from '../../utils/moderation/automodService.ts';
 
 type ConfigSection = 'logs' | 'moderation' | 'birthdays' | 'mute' | 'reports' | 'tickets' | 'xp' | 'invites' | 'timezone';
@@ -76,7 +78,9 @@ type AutoModRuleKey =
     | 'anti_spam_enabled'
     | 'anti_duplicate_enabled'
     | 'anti_caps_enabled'
-    | 'anti_mention_enabled';
+    | 'anti_mention_enabled'
+    | 'anti_keyword_enabled'
+    | 'anti_raid_enabled';
 
 const PANEL_COLOR = KEPLER_COLORS.primary;
 const PANEL_TIMEOUT = 5 * 60 * 1000;
@@ -264,6 +268,13 @@ async function handleComponent(component: MessageComponentInteraction, source: C
             await component.editReply(await buildAutoModHome(guild));
             return;
         }
+        if (component.customId === 'settings:automod:observation') {
+            const settings = await getAutoModSettings(guild.id);
+            await component.deferUpdate();
+            await updateAutoModSettings(guild.id, { observation_mode: !settings.observation_mode });
+            await component.editReply(await buildAutoModHome(guild));
+            return;
+        }
         if (component.customId === 'settings:automod:thresholds') {
             await showAutoModThresholdsModal(component, source);
             return;
@@ -272,8 +283,16 @@ async function handleComponent(component: MessageComponentInteraction, source: C
             await showAutoModActionModal(component, source);
             return;
         }
+        if (component.customId === 'settings:automod:rule-actions') {
+            await showAutoModRuleActionsModal(component, source);
+            return;
+        }
         if (component.customId === 'settings:automod:domains') {
             await showAutoModDomainsModal(component, source);
+            return;
+        }
+        if (component.customId === 'settings:automod:keywords') {
+            await showAutoModKeywordsModal(component, source);
             return;
         }
         if (component.customId === 'settings:automod:exemptions') {
@@ -973,9 +992,10 @@ async function buildInviteFields(guild: Guild) {
 }
 
 async function buildAutoModHome(guild: Guild) {
-    const [settings, logChannelId] = await Promise.all([
+    const [settings, logChannelId, stats] = await Promise.all([
         getAutoModSettings(guild.id),
-        getModerationChannel(guild.id)
+        getModerationChannel(guild.id),
+        getAutoModStats(guild.id).catch(() => ({ total: 0, observed: 0, byRule: {} }))
     ]);
     const activeRules = [
         settings.anti_link_enabled,
@@ -983,7 +1003,9 @@ async function buildAutoModHome(guild: Guild) {
         settings.anti_spam_enabled,
         settings.anti_duplicate_enabled,
         settings.anti_caps_enabled,
-        settings.anti_mention_enabled
+        settings.anti_mention_enabled,
+        settings.anti_keyword_enabled,
+        settings.anti_raid_enabled
     ].filter(Boolean).length;
     const logSelect = new ChannelSelectMenuBuilder()
         .setCustomId('settings:automod:log-channel')
@@ -999,7 +1021,7 @@ async function buildAutoModHome(guild: Guild) {
         )
         .addFields(
             { name: 'Moteur', value: settings.enabled ? '🟢 Actif' : '⚪ Désactivé', inline: true },
-            { name: 'Protections', value: `${activeRules}/6 actives`, inline: true },
+            { name: 'Protections', value: `${activeRules}/8 actives`, inline: true },
             { name: 'Logs', value: formatChannel(guild, logChannelId), inline: true },
             {
                 name: 'Réponse',
@@ -1012,6 +1034,11 @@ async function buildAutoModHome(guild: Guild) {
                 name: 'Tolérances',
                 value: `${settings.allowed_domains.length} domaine(s) · ` +
                     `${settings.excluded_channel_ids.length} salon(s) · ${settings.excluded_role_ids.length} rôle(s)`,
+                inline: false
+            },
+            {
+                name: '7 derniers jours',
+                value: `${stats.total} détection(s) · ${stats.observed} observée(s) sans sanction`,
                 inline: false
             }
         )
@@ -1033,10 +1060,15 @@ async function buildAutoModHome(guild: Guild) {
             ),
             new ActionRowBuilder<ButtonBuilder>().addComponents(
                 new ButtonBuilder().setCustomId('settings:automod:domains').setLabel('Domaines autorisés').setEmoji('🌐').setStyle(ButtonStyle.Secondary),
+                new ButtonBuilder().setCustomId('settings:automod:keywords').setLabel('Mots et regex').setEmoji('📝').setStyle(ButtonStyle.Secondary),
                 new ButtonBuilder()
                     .setCustomId('settings:automod:own-invites')
                     .setLabel(settings.allow_own_invites ? 'Invitations du serveur autorisées' : 'Toutes les invitations bloquées')
                     .setStyle(settings.allow_own_invites ? ButtonStyle.Success : ButtonStyle.Secondary),
+                new ButtonBuilder()
+                    .setCustomId('settings:automod:observation')
+                    .setLabel(settings.observation_mode ? 'Observation active' : 'Mode observation')
+                    .setStyle(settings.observation_mode ? ButtonStyle.Success : ButtonStyle.Secondary),
                 backButton()
             )
         ]
@@ -1051,7 +1083,9 @@ async function buildAutoModRules(guild: Guild) {
         ['anti_spam_enabled', 'Rafales', '⚡'],
         ['anti_duplicate_enabled', 'Doublons', '📋'],
         ['anti_caps_enabled', 'Majuscules', '🔠'],
-        ['anti_mention_enabled', 'Mentions', '📣']
+        ['anti_mention_enabled', 'Mentions', '📣'],
+        ['anti_keyword_enabled', 'Mots interdits', '📝'],
+        ['anti_raid_enabled', 'Anti-raid', '🚨']
     ];
     const makeButton = ([key, label, emoji]: [AutoModRuleKey, string, string]) =>
         new ButtonBuilder()
@@ -1074,6 +1108,7 @@ async function buildAutoModRules(guild: Guild) {
             new ActionRowBuilder<ButtonBuilder>().addComponents(...rules.slice(0, 3).map(makeButton)),
             new ActionRowBuilder<ButtonBuilder>().addComponents(...rules.slice(3).map(makeButton)),
             new ActionRowBuilder<ButtonBuilder>().addComponents(
+                new ButtonBuilder().setCustomId('settings:automod:rule-actions').setLabel('Actions par règle').setEmoji('⚖️').setStyle(ButtonStyle.Primary),
                 new ButtonBuilder().setCustomId('settings:automod:home').setLabel('Retour à l’AutoMod').setEmoji('↩️').setStyle(ButtonStyle.Secondary)
             )
         ]
@@ -1505,7 +1540,14 @@ async function showAutoModActionModal(component: ButtonInteraction, source: Chat
             settingsTextInput('action', 'Action : delete, warn ou timeout', settings.action, 'timeout'),
             settingsTextInput('strikes', 'Infractions / fenêtre en secondes', `${settings.strike_threshold}/${settings.strike_window_seconds}`, '3/3600'),
             settingsTextInput('timeout', 'Durée du timeout en secondes', String(settings.timeout_seconds), '600'),
-            settingsTextInput('notify', 'Notifier l’utilisateur en MP ? oui/non', settings.notify_user ? 'oui' : 'non', 'oui')
+            settingsTextInput('notify', 'Notifier l’utilisateur en MP ? oui/non', settings.notify_user ? 'oui' : 'non', 'oui'),
+            settingsTextInput(
+                'policy',
+                'Paliers : seuil=action[:secondes]',
+                settings.escalation_steps.map(step => `${step.strikes}=${step.action}${step.timeout_seconds ? `:${step.timeout_seconds}` : ''}`).join(','),
+                '1=delete,2=warn,3=timeout:600',
+                false
+            )
         );
     await component.showModal(modal);
     const submission = await awaitSettingsModal(component, source, modalId);
@@ -1514,14 +1556,15 @@ async function showAutoModActionModal(component: ButtonInteraction, source: Chat
     const strikes = parseNumberPair(submission.fields.getTextInputValue('strikes'));
     const timeout = Number(submission.fields.getTextInputValue('timeout'));
     const notify = submission.fields.getTextInputValue('notify').trim().toLowerCase();
+    const policy = parseEscalationPolicy(submission.fields.getTextInputValue('policy'));
     if (
         !['delete', 'warn', 'timeout'].includes(action) ||
         !strikes || strikes[0] < 1 || strikes[0] > 20 || strikes[1] < 60 || strikes[1] > 604800 ||
         !Number.isInteger(timeout) || timeout < 10 || timeout > 2419200 ||
-        !['oui', 'non'].includes(notify)
+        !['oui', 'non'].includes(notify) || policy === null
     ) {
         await submission.reply({
-            content: '❌ Utilisez `delete`, `warn` ou `timeout`, une progression `1-20/60-604800`, un timeout de 10 à 2419200 secondes et `oui`/`non`.',
+            content: '❌ Paramètres invalides. Exemple de paliers : `1=delete,2=warn,3=timeout:600`.',
             ephemeral: true
         });
         return;
@@ -1532,9 +1575,112 @@ async function showAutoModActionModal(component: ButtonInteraction, source: Chat
         strike_threshold: strikes[0],
         strike_window_seconds: strikes[1],
         timeout_seconds: timeout,
-        notify_user: notify === 'oui'
+        notify_user: notify === 'oui',
+        escalation_steps: policy
     });
     await submission.editReply(await buildAutoModHome(source.guild!));
+}
+
+async function showAutoModKeywordsModal(component: ButtonInteraction, source: ChatInputCommandInteraction) {
+    const settings = await getAutoModSettings(source.guildId!);
+    const modalId = `settings:automod:keywords-modal:${source.id}`;
+    const paragraph = (id: string, label: string, values: string[], placeholder: string) =>
+        new ActionRowBuilder<TextInputBuilder>().addComponents(
+            new TextInputBuilder()
+                .setCustomId(id)
+                .setLabel(label)
+                .setPlaceholder(placeholder)
+                .setStyle(TextInputStyle.Paragraph)
+                .setValue(values.join('\n').slice(0, 4000))
+                .setMaxLength(4000)
+                .setRequired(false)
+        );
+    const modal = new ModalBuilder()
+        .setCustomId(modalId)
+        .setTitle('Filtres personnalisés')
+        .addComponents(
+            paragraph('blocked', 'Termes interdits, un par ligne', settings.blocked_keywords, 'terme interdit'),
+            paragraph('allowed', 'Exceptions, une par ligne', settings.allowed_keywords, 'expression autorisée'),
+            paragraph('regex', 'Expressions régulières, une par ligne', settings.regex_patterns, '^exemple\\d+$')
+        );
+    await component.showModal(modal);
+    const submission = await awaitSettingsModal(component, source, modalId);
+    if (!submission) return;
+    const lines = (id: string) => [...new Set(submission.fields.getTextInputValue(id)
+        .split('\n').map(value => value.trim()).filter(Boolean))];
+    const blocked = lines('blocked');
+    const allowed = lines('allowed');
+    const regex = lines('regex');
+    if (blocked.length > 250 || allowed.length > 100 || regex.length > 10 || regex.some(pattern => {
+        try { new RegExp(pattern, 'iu'); return false; } catch { return true; }
+    })) {
+        await submission.reply({ content: '❌ Maximum : 250 termes, 100 exceptions et 10 expressions régulières valides.', ephemeral: true });
+        return;
+    }
+    await submission.deferUpdate();
+    await updateAutoModSettings(source.guildId!, {
+        blocked_keywords: blocked,
+        allowed_keywords: allowed,
+        regex_patterns: regex
+    });
+    await submission.editReply(await buildAutoModHome(source.guild!));
+}
+
+function parseEscalationPolicy(value: string): AutoModEscalationStep[] | null {
+    if (!value.trim()) return [];
+    const steps: AutoModEscalationStep[] = [];
+    for (const raw of value.split(',')) {
+        const match = raw.trim().match(/^(\d+)=(delete|warn|timeout)(?::(\d+))?$/i);
+        if (!match) return null;
+        const strikes = Number(match[1]);
+        const action = match[2].toLowerCase() as 'delete' | 'warn' | 'timeout';
+        const timeout_seconds = match[3] ? Number(match[3]) : undefined;
+        if (strikes < 1 || strikes > 20 || (action === 'timeout' && timeout_seconds !== undefined && (timeout_seconds < 10 || timeout_seconds > 2419200))) return null;
+        steps.push({ strikes, action, ...(timeout_seconds ? { timeout_seconds } : {}) });
+    }
+    return steps;
+}
+
+async function showAutoModRuleActionsModal(component: ButtonInteraction, source: ChatInputCommandInteraction) {
+    const settings = await getAutoModSettings(source.guildId!);
+    const modalId = `settings:automod:rule-actions-modal:${source.id}`;
+    const value = Object.entries(settings.rule_actions).map(([rule, action]) => `${rule}=${action}`).join(',');
+    const modal = new ModalBuilder()
+        .setCustomId(modalId)
+        .setTitle('Actions par règle')
+        .addComponents(settingsTextInput(
+            'actions',
+            'règle=action, séparées par virgule',
+            value,
+            'link=delete,spam=warn,mentions=timeout',
+            false
+        ));
+    await component.showModal(modal);
+    const submission = await awaitSettingsModal(component, source, modalId);
+    if (!submission) return;
+    const parsed = parseRuleActions(submission.fields.getTextInputValue('actions'));
+    if (!parsed) {
+        await submission.reply({
+            content: '❌ Règles : `link`, `invite`, `spam`, `duplicate`, `caps`, `mentions`, `keyword`. Actions : `delete`, `warn`, `timeout`.',
+            ephemeral: true
+        });
+        return;
+    }
+    await submission.deferUpdate();
+    await updateAutoModSettings(source.guildId!, { rule_actions: parsed });
+    await submission.editReply(await buildAutoModRules(source.guild!));
+}
+
+function parseRuleActions(value: string) {
+    const result: Record<string, 'delete' | 'warn' | 'timeout'> = {};
+    if (!value.trim()) return result;
+    const validRules = new Set(['link', 'invite', 'spam', 'duplicate', 'caps', 'mentions', 'keyword']);
+    for (const raw of value.split(',')) {
+        const match = raw.trim().match(/^(\w+)=(delete|warn|timeout)$/i);
+        if (!match || !validRules.has(match[1].toLowerCase())) return null;
+        result[match[1].toLowerCase()] = match[2].toLowerCase() as 'delete' | 'warn' | 'timeout';
+    }
+    return result;
 }
 
 async function showAutoModDomainsModal(component: ButtonInteraction, source: ChatInputCommandInteraction) {
@@ -1574,16 +1720,15 @@ async function showAutoModDomainsModal(component: ButtonInteraction, source: Cha
     await submission.editReply(await buildAutoModHome(source.guild!));
 }
 
-function settingsTextInput(customId: string, label: string, value: string, placeholder: string) {
-    return new ActionRowBuilder<TextInputBuilder>().addComponents(
-        new TextInputBuilder()
-            .setCustomId(customId)
-            .setLabel(label)
-            .setStyle(TextInputStyle.Short)
-            .setValue(value)
-            .setPlaceholder(placeholder)
-            .setRequired(true)
-    );
+function settingsTextInput(customId: string, label: string, value: string, placeholder: string, required = true) {
+    const input = new TextInputBuilder()
+        .setCustomId(customId)
+        .setLabel(label)
+        .setStyle(TextInputStyle.Short)
+        .setPlaceholder(placeholder)
+        .setRequired(required);
+    if (value) input.setValue(value);
+    return new ActionRowBuilder<TextInputBuilder>().addComponents(input);
 }
 
 function parseNumberPair(value: string): [number, number] | null {

--- a/commands/administration/settings.ts
+++ b/commands/administration/settings.ts
@@ -64,7 +64,7 @@ import {
     type AutoModEscalationStep
 } from '../../utils/moderation/automodService.ts';
 
-type ConfigSection = 'logs' | 'moderation' | 'birthdays' | 'mute' | 'reports' | 'tickets' | 'xp' | 'invites' | 'timezone';
+type ConfigSection = 'logs' | 'moderation' | 'birthdays' | 'mute' | 'reports' | 'tickets' | 'tickets-placement' | 'xp' | 'invites' | 'timezone';
 type InviteDisplayKey =
     | 'show_invite_code'
     | 'show_inviter'
@@ -345,35 +345,35 @@ async function handleComponent(component: MessageComponentInteraction, source: C
             const settings = await getInviteSettings(guild.id);
             await component.deferUpdate();
             await updateInviteSettings(guild.id, { enabled: !settings.enabled });
-            await component.editReply(await buildInviteSection(guild));
+            await component.editReply(await buildInviteGeneral(guild));
             return;
         }
         if (component.customId === 'settings:invites:welcome-toggle') {
             const settings = await getInviteSettings(guild.id);
             await component.deferUpdate();
             await updateInviteSettings(guild.id, { welcome_enabled: !settings.welcome_enabled });
-            await component.editReply(await buildInviteSection(guild));
+            await component.editReply(await buildInviteWelcome(guild));
             return;
         }
         if (component.customId === 'settings:invites:create-log-toggle') {
             const settings = await getInviteSettings(guild.id);
             await component.deferUpdate();
             await updateInviteSettings(guild.id, { log_invite_create: !settings.log_invite_create });
-            await component.editReply(await buildInviteSection(guild));
+            await component.editReply(await buildInviteLogs(guild));
             return;
         }
         if (component.customId === 'settings:invites:delete-log-toggle') {
             const settings = await getInviteSettings(guild.id);
             await component.deferUpdate();
             await updateInviteSettings(guild.id, { log_invite_delete: !settings.log_invite_delete });
-            await component.editReply(await buildInviteSection(guild));
+            await component.editReply(await buildInviteLogs(guild));
             return;
         }
         if (component.customId === 'settings:invites:use-log-toggle') {
             const settings = await getInviteSettings(guild.id);
             await component.deferUpdate();
             await updateInviteSettings(guild.id, { log_invite_use: !settings.log_invite_use });
-            await component.editReply(await buildInviteSection(guild));
+            await component.editReply(await buildInviteLogs(guild));
             return;
         }
         if (component.customId === 'settings:invites:customize') {
@@ -382,6 +382,22 @@ async function handleComponent(component: MessageComponentInteraction, source: C
         }
         if (component.customId === 'settings:invites:fields') {
             await component.update(await buildInviteFields(guild));
+            return;
+        }
+        if (component.customId === 'settings:invites:general') {
+            await component.update(await buildInviteGeneral(guild));
+            return;
+        }
+        if (component.customId === 'settings:invites:channels') {
+            await component.update(await buildInviteChannels(guild));
+            return;
+        }
+        if (component.customId === 'settings:invites:logs') {
+            await component.update(await buildInviteLogs(guild));
+            return;
+        }
+        if (component.customId === 'settings:invites:welcome') {
+            await component.update(await buildInviteWelcome(guild));
             return;
         }
         if (component.customId === 'settings:invites:home') {
@@ -403,7 +419,7 @@ async function handleComponent(component: MessageComponentInteraction, source: C
                 welcome_channel_id: null,
                 welcome_enabled: false
             });
-            await component.editReply(await buildInviteSection(guild));
+            await component.editReply(await buildInviteChannels(guild));
             return;
         }
         if (component.customId.startsWith('settings:disable:')) {
@@ -424,6 +440,10 @@ async function handleComponent(component: MessageComponentInteraction, source: C
         }
         if (component.customId === 'settings:tickets:customize') {
             await customizeTicketPanel(component, source);
+            return;
+        }
+        if (component.customId === 'settings:tickets:placement') {
+            await component.update(await buildSection('tickets-placement', guild));
             return;
         }
         if (component.customId === 'settings:tickets:publish') {
@@ -479,7 +499,7 @@ async function handleComponent(component: MessageComponentInteraction, source: C
         if (component.customId === 'settings:invites:log-channel') {
             await component.deferUpdate();
             await updateInviteSettings(guild.id, { log_channel_id: channelId });
-            await component.editReply(await buildInviteSection(guild));
+            await component.editReply(await buildInviteChannels(guild));
             return;
         }
         if (component.customId === 'settings:invites:welcome-channel') {
@@ -488,7 +508,7 @@ async function handleComponent(component: MessageComponentInteraction, source: C
                 welcome_channel_id: channelId,
                 welcome_enabled: true
             });
-            await component.editReply(await buildInviteSection(guild));
+            await component.editReply(await buildInviteChannels(guild));
             return;
         }
         if (component.customId === 'settings:automod:log-channel') {
@@ -506,17 +526,17 @@ async function handleComponent(component: MessageComponentInteraction, source: C
         await component.deferUpdate();
         if (component.customId === 'settings:select:tickets-category') {
             await updateTicketConfig(guild.id, { ticket_category_id: channelId });
-            await confirmSettingChange(component, source, 'tickets', `Catégorie des tickets configurée sur <#${channelId}>.`);
+            await component.editReply(await buildSection('tickets-placement', guild));
             return;
         }
         if (component.customId === 'settings:select:tickets-logs') {
             await updateTicketConfig(guild.id, { ticket_log_channel_id: channelId });
-            await confirmSettingChange(component, source, 'tickets', `Salon des logs de tickets configuré sur <#${channelId}>.`);
+            await component.editReply(await buildSection('tickets-placement', guild));
             return;
         }
         if (component.customId === 'settings:select:tickets-channel') {
             await updateTicketConfig(guild.id, { ticket_panel_channel_id: channelId });
-            await confirmSettingChange(component, source, 'tickets', `Salon du panneau configuré sur <#${channelId}>.`);
+            await component.editReply(await buildSection('tickets-placement', guild));
             return;
         }
         if (component.customId === 'settings:select:reports-channel') {
@@ -567,7 +587,7 @@ async function handleComponent(component: MessageComponentInteraction, source: C
             }
             await component.deferUpdate();
             await updateTicketConfig(guild.id, { ticket_support_role_id: role.id });
-            await confirmSettingChange(component, source, 'tickets', `Rôle support configuré sur ${role}.`);
+            await component.editReply(await buildSection('tickets-placement', guild));
             return;
         }
         if (component.customId === 'settings:select:reports-role') {
@@ -717,18 +737,53 @@ function getDashboardUrl(guildId: string): string | null {
     }
 }
 
+async function buildTicketHome(guild: Guild) {
+    const config = await getTicketConfig(guild.id);
+    const ready = Boolean(
+        config.ticket_panel_channel_id && config.ticket_category_id &&
+        config.ticket_log_channel_id && config.ticket_support_role_id
+    );
+    return {
+        content: '',
+        embeds: [
+            createKeplerEmbed(ready ? 'primary' : 'neutral')
+                .setTitle('Tickets')
+                .setDescription('Préparez les emplacements et l’apparence du panneau, puis publiez-le lorsqu’il est prêt.')
+                .addFields(
+                    { name: 'État', value: ready ? '🟢 Configuration complète' : '🟠 Configuration incomplète', inline: false },
+                    { name: 'Panneau', value: formatChannel(guild, config.ticket_panel_channel_id), inline: true },
+                    { name: 'Catégorie', value: formatChannel(guild, config.ticket_category_id), inline: true },
+                    { name: 'Journal', value: formatChannel(guild, config.ticket_log_channel_id), inline: true },
+                    { name: 'Rôle support', value: formatOptionalRole(guild, config.ticket_support_role_id), inline: true },
+                    { name: 'Titre du panneau', value: config.ticket_panel_title, inline: false }
+                )
+                .setFooter({ text: guild.name })
+        ],
+        components: [
+            new ActionRowBuilder<ButtonBuilder>().addComponents(
+                new ButtonBuilder().setCustomId('settings:tickets:placement').setLabel('Emplacements et accès').setEmoji('📍').setStyle(ButtonStyle.Primary),
+                new ButtonBuilder().setCustomId('settings:tickets:customize').setLabel('Apparence du panneau').setEmoji('✏️').setStyle(ButtonStyle.Secondary),
+                new ButtonBuilder().setCustomId('settings:tickets:publish').setLabel('Publier le panneau').setEmoji('📨').setStyle(ButtonStyle.Success),
+                new ButtonBuilder().setCustomId('settings:disable:tickets').setLabel('Désactiver').setStyle(ButtonStyle.Danger)
+            ),
+            new ActionRowBuilder<ButtonBuilder>().addComponents(backButton())
+        ]
+    };
+}
+
 async function buildSection(section: ConfigSection, guild: Guild) {
     if (section === 'xp') return buildXpHome(guild);
     if (section === 'invites') return buildInviteSection(guild);
     if (section === 'timezone') return buildTimezoneSection(guild);
     if (section === 'moderation') return buildModerationHub(guild);
+    if (section === 'tickets') return buildTicketHome(guild);
     const embed = createKeplerEmbed()
         .setColor(PANEL_COLOR)
         .setTitle(sectionLabel(section))
         .setDescription(sectionDescription(section))
         .setFooter({ text: guild.name });
 
-    if (section === 'tickets') {
+    if (section === 'tickets-placement') {
         const config = await getTicketConfig(guild.id);
         const channelSelect = new ChannelSelectMenuBuilder()
             .setCustomId('settings:select:tickets-channel')
@@ -774,10 +829,7 @@ async function buildSection(section: ConfigSection, guild: Guild) {
                 new ActionRowBuilder<RoleSelectMenuBuilder>().addComponents(roleSelect),
                 new ActionRowBuilder<ChannelSelectMenuBuilder>().addComponents(logChannelSelect),
                 new ActionRowBuilder<ButtonBuilder>().addComponents(
-                    new ButtonBuilder().setCustomId('settings:tickets:customize').setLabel('Personnaliser').setEmoji('✏️').setStyle(ButtonStyle.Primary),
-                    new ButtonBuilder().setCustomId('settings:tickets:publish').setLabel('Publier').setEmoji('📨').setStyle(ButtonStyle.Success),
-                    new ButtonBuilder().setCustomId('settings:disable:tickets').setLabel('Désactiver').setStyle(ButtonStyle.Danger),
-                    backButton()
+                    ticketBackButton()
                 )
             ]
         };
@@ -908,74 +960,107 @@ async function buildTimezoneSection(guild: Guild) {
 
 async function buildInviteSection(guild: Guild) {
     const settings = await getInviteSettings(guild.id);
-    const logChannel = new ChannelSelectMenuBuilder()
-        .setCustomId('settings:invites:log-channel')
-        .setPlaceholder('Choisir le salon des logs d’invitations')
-        .addChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement)
-        .setMinValues(1)
-        .setMaxValues(1);
-    const welcomeChannel = new ChannelSelectMenuBuilder()
-        .setCustomId('settings:invites:welcome-channel')
-        .setPlaceholder('Choisir le salon des messages d’arrivée')
-        .addChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement)
-        .setMinValues(1)
-        .setMaxValues(1);
-    const embed = createKeplerEmbed(settings.enabled ? 'primary' : 'neutral')
-        .setTitle('Manager d’invitations')
-        .setDescription(
-            'Kepler compare les utilisations des liens lors de chaque arrivée. ' +
-            'Il faut lui accorder la permission **Gérer le serveur** pour consulter les invitations.\n\n' +
-            'Variables du message : `{membre}`, `{membre_nom}`, `{serveur}`, `{code}`, `{inviteur}`, ' +
-            '`{utilisations}`, `{membres}`, `{canal}`.'
-        )
-        .addFields(
-            { name: 'Système', value: settings.enabled ? '🟢 Actif' : '⚪ Désactivé', inline: true },
-            { name: 'Logs', value: formatChannel(guild, settings.log_channel_id), inline: true },
-            {
-                name: 'Annonce d’arrivée',
-                value: settings.welcome_enabled
-                    ? formatChannel(guild, settings.welcome_channel_id)
-                    : '⚪ Désactivée',
-                inline: true
-            },
-            { name: 'Message', value: settings.welcome_message.slice(0, 1024), inline: false }
-        )
-        .setFooter({ text: guild.name });
     return {
         content: '',
-        embeds: [embed],
+        embeds: [
+            createKeplerEmbed(settings.enabled ? 'primary' : 'neutral')
+                .setTitle('Invitations')
+                .setDescription('Configurez le suivi des liens et les annonces d’arrivée depuis les rubriques ci-dessous.')
+                .addFields(
+                    { name: 'Système', value: settings.enabled ? '🟢 Actif' : '⚪ Désactivé', inline: true },
+                    { name: 'Journal', value: formatChannel(guild, settings.log_channel_id), inline: true },
+                    {
+                        name: 'Annonce d’arrivée',
+                        value: settings.welcome_enabled ? formatChannel(guild, settings.welcome_channel_id) : '⚪ Désactivée',
+                        inline: true
+                    }
+                )
+                .setFooter({ text: guild.name })
+        ],
+        components: [
+            new ActionRowBuilder<ButtonBuilder>().addComponents(
+                new ButtonBuilder().setCustomId('settings:invites:general').setLabel('Général').setEmoji('⚙️').setStyle(ButtonStyle.Primary),
+                new ButtonBuilder().setCustomId('settings:invites:channels').setLabel('Salons').setEmoji('📍').setStyle(ButtonStyle.Secondary),
+                new ButtonBuilder().setCustomId('settings:invites:logs').setLabel('Événements journalisés').setEmoji('🧾').setStyle(ButtonStyle.Secondary),
+                new ButtonBuilder().setCustomId('settings:invites:welcome').setLabel('Annonce d’arrivée').setEmoji('👋').setStyle(ButtonStyle.Secondary)
+            ),
+            new ActionRowBuilder<ButtonBuilder>().addComponents(backButton())
+        ]
+    };
+}
+
+async function buildInviteGeneral(guild: Guild) {
+    const settings = await getInviteSettings(guild.id);
+    return {
+        content: '',
+        embeds: [createKeplerEmbed(settings.enabled ? 'primary' : 'neutral')
+            .setTitle('Invitations · Général')
+            .setDescription('Le bot doit disposer de la permission **Gérer le serveur** pour comparer les utilisations des liens.')
+            .addFields({ name: 'Manager', value: settings.enabled ? '🟢 Actif' : '⚪ Désactivé', inline: true })
+            .setFooter({ text: guild.name })],
+        components: [new ActionRowBuilder<ButtonBuilder>().addComponents(
+            new ButtonBuilder().setCustomId('settings:invites:toggle').setLabel(settings.enabled ? 'Désactiver' : 'Activer').setStyle(settings.enabled ? ButtonStyle.Danger : ButtonStyle.Success),
+            inviteBackButton()
+        )]
+    };
+}
+
+async function buildInviteChannels(guild: Guild) {
+    const settings = await getInviteSettings(guild.id);
+    const logChannel = new ChannelSelectMenuBuilder().setCustomId('settings:invites:log-channel')
+        .setPlaceholder('Salon du journal d’invitations').addChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement).setMinValues(1).setMaxValues(1);
+    const welcomeChannel = new ChannelSelectMenuBuilder().setCustomId('settings:invites:welcome-channel')
+        .setPlaceholder('Salon des annonces d’arrivée').addChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement).setMinValues(1).setMaxValues(1);
+    if (settings.log_channel_id && guild.channels.cache.has(settings.log_channel_id)) logChannel.setDefaultChannels(settings.log_channel_id);
+    if (settings.welcome_channel_id && guild.channels.cache.has(settings.welcome_channel_id)) welcomeChannel.setDefaultChannels(settings.welcome_channel_id);
+    return {
+        content: '',
+        embeds: [createKeplerEmbed('primary').setTitle('Invitations · Salons').addFields(
+            { name: 'Journal', value: formatChannel(guild, settings.log_channel_id), inline: true },
+            { name: 'Annonces', value: formatChannel(guild, settings.welcome_channel_id), inline: true }
+        ).setFooter({ text: guild.name })],
         components: [
             new ActionRowBuilder<ChannelSelectMenuBuilder>().addComponents(logChannel),
             new ActionRowBuilder<ChannelSelectMenuBuilder>().addComponents(welcomeChannel),
             new ActionRowBuilder<ButtonBuilder>().addComponents(
-                new ButtonBuilder()
-                    .setCustomId('settings:invites:toggle')
-                    .setLabel(settings.enabled ? 'Désactiver le manager' : 'Activer le manager')
-                    .setStyle(settings.enabled ? ButtonStyle.Danger : ButtonStyle.Success),
-                new ButtonBuilder()
-                    .setCustomId('settings:invites:welcome-toggle')
-                    .setLabel(settings.welcome_enabled ? 'Couper les annonces' : 'Activer les annonces')
-                    .setStyle(settings.welcome_enabled ? ButtonStyle.Secondary : ButtonStyle.Success),
-                new ButtonBuilder()
-                    .setCustomId('settings:invites:create-log-toggle')
-                    .setLabel('Logs création')
-                    .setStyle(settings.log_invite_create ? ButtonStyle.Success : ButtonStyle.Secondary),
-                new ButtonBuilder()
-                    .setCustomId('settings:invites:delete-log-toggle')
-                    .setLabel('Logs suppression')
-                    .setStyle(settings.log_invite_delete ? ButtonStyle.Success : ButtonStyle.Secondary),
-                new ButtonBuilder()
-                    .setCustomId('settings:invites:use-log-toggle')
-                    .setLabel('Logs arrivée')
-                    .setStyle(settings.log_invite_use ? ButtonStyle.Success : ButtonStyle.Secondary)
-            ),
-            new ActionRowBuilder<ButtonBuilder>().addComponents(
-                new ButtonBuilder().setCustomId('settings:invites:customize').setLabel('Personnaliser').setEmoji('✏️').setStyle(ButtonStyle.Primary),
-                new ButtonBuilder().setCustomId('settings:invites:fields').setLabel('Informations affichées').setEmoji('🧩').setStyle(ButtonStyle.Secondary),
-                new ButtonBuilder().setCustomId('settings:invites:clear-channels').setLabel('Retirer les salons').setStyle(ButtonStyle.Danger)
-            ),
-            new ActionRowBuilder<ButtonBuilder>().addComponents(backButton())
+                new ButtonBuilder().setCustomId('settings:invites:clear-channels').setLabel('Retirer les salons').setStyle(ButtonStyle.Danger),
+                inviteBackButton()
+            )
         ]
+    };
+}
+
+async function buildInviteLogs(guild: Guild) {
+    const settings = await getInviteSettings(guild.id);
+    return {
+        content: '',
+        embeds: [createKeplerEmbed('primary').setTitle('Invitations · Événements journalisés')
+            .setDescription('Choisissez précisément les événements envoyés dans le journal d’invitations.')
+            .setFooter({ text: guild.name })],
+        components: [new ActionRowBuilder<ButtonBuilder>().addComponents(
+            new ButtonBuilder().setCustomId('settings:invites:create-log-toggle').setLabel('Création de lien').setStyle(settings.log_invite_create ? ButtonStyle.Success : ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('settings:invites:delete-log-toggle').setLabel('Suppression de lien').setStyle(settings.log_invite_delete ? ButtonStyle.Success : ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('settings:invites:use-log-toggle').setLabel('Arrivée détectée').setStyle(settings.log_invite_use ? ButtonStyle.Success : ButtonStyle.Secondary),
+            inviteBackButton()
+        )]
+    };
+}
+
+async function buildInviteWelcome(guild: Guild) {
+    const settings = await getInviteSettings(guild.id);
+    return {
+        content: '',
+        embeds: [createKeplerEmbed(settings.welcome_enabled ? 'primary' : 'neutral').setTitle('Invitations · Annonce d’arrivée')
+            .setDescription(settings.welcome_message.slice(0, 1500)).addFields(
+                { name: 'État', value: settings.welcome_enabled ? '🟢 Active' : '⚪ Désactivée', inline: true },
+                { name: 'Salon', value: formatChannel(guild, settings.welcome_channel_id), inline: true }
+            ).setFooter({ text: guild.name })],
+        components: [new ActionRowBuilder<ButtonBuilder>().addComponents(
+            new ButtonBuilder().setCustomId('settings:invites:welcome-toggle').setLabel(settings.welcome_enabled ? 'Désactiver' : 'Activer').setStyle(settings.welcome_enabled ? ButtonStyle.Danger : ButtonStyle.Success),
+            new ButtonBuilder().setCustomId('settings:invites:customize').setLabel('Modifier le message').setEmoji('✏️').setStyle(ButtonStyle.Primary),
+            new ButtonBuilder().setCustomId('settings:invites:fields').setLabel('Informations affichées').setEmoji('🧩').setStyle(ButtonStyle.Secondary),
+            inviteBackButton()
+        )]
     };
 }
 
@@ -1010,7 +1095,7 @@ async function buildInviteFields(guild: Guild) {
             new ActionRowBuilder<ButtonBuilder>().addComponents(...choices.slice(0, 3).map(button)),
             new ActionRowBuilder<ButtonBuilder>().addComponents(...choices.slice(3).map(button)),
             new ActionRowBuilder<ButtonBuilder>().addComponents(
-                new ButtonBuilder().setCustomId('settings:invites:home').setLabel('Retour aux invitations').setEmoji('↩️').setStyle(ButtonStyle.Secondary)
+                new ButtonBuilder().setCustomId('settings:invites:welcome').setLabel('Retour à l’annonce').setEmoji('↩️').setStyle(ButtonStyle.Secondary)
             )
         ]
     };
@@ -1932,7 +2017,7 @@ async function showInviteMessageModal(component: ButtonInteraction, source: Chat
     const message = submission.fields.getTextInputValue('message').trim();
     await submission.deferUpdate();
     await updateInviteSettings(source.guildId!, { welcome_message: message });
-    await submission.editReply(await buildInviteSection(source.guild!));
+    await submission.editReply(await buildInviteWelcome(source.guild!));
 }
 
 async function showXpGeneralModal(component: ButtonInteraction, source: ChatInputCommandInteraction) {
@@ -2386,6 +2471,7 @@ function sectionLabel(section: ConfigSection): string {
         mute: 'Rôle de mute',
         reports: 'Signalements',
         tickets: 'Tickets',
+        'tickets-placement': 'Tickets · Emplacements et accès',
         xp: 'Expérience et niveaux',
         invites: 'Manager d’invitations',
         timezone: 'Fuseau horaire'
@@ -2400,6 +2486,7 @@ function sectionDescription(section: ConfigSection): string {
         mute: 'Sélectionnez un rôle existant, créez-en un automatiquement ou utilisez les timeouts Discord.',
         reports: 'Choisissez le salon qui recevra les signalements et, si nécessaire, le rôle de modération à mentionner.',
         tickets: 'Choisissez où publier le panneau, le rôle support, puis personnalisez son message et son bouton.',
+        'tickets-placement': 'Choisissez les salons, la catégorie et le rôle autorisé à traiter les tickets.',
         xp: 'Configurez la progression, les boosts, les récompenses et les exclusions du serveur.',
         invites: 'Configurez le suivi des liens, les journaux et les annonces d’arrivée.',
         timezone: 'Choisissez le fuseau utilisé pour les dates et planifications du serveur.'
@@ -2444,6 +2531,22 @@ function autoModBackButton(): ButtonBuilder {
     return new ButtonBuilder()
         .setCustomId('settings:automod:home')
         .setLabel('Retour à l’AutoMod')
+        .setEmoji('↩️')
+        .setStyle(ButtonStyle.Secondary);
+}
+
+function inviteBackButton(): ButtonBuilder {
+    return new ButtonBuilder()
+        .setCustomId('settings:invites:home')
+        .setLabel('Retour aux invitations')
+        .setEmoji('↩️')
+        .setStyle(ButtonStyle.Secondary);
+}
+
+function ticketBackButton(): ButtonBuilder {
+    return new ButtonBuilder()
+        .setCustomId('settings:section:tickets')
+        .setLabel('Retour aux tickets')
         .setEmoji('↩️')
         .setStyle(ButtonStyle.Secondary);
 }

--- a/commands/administration/settings.ts
+++ b/commands/administration/settings.ts
@@ -242,11 +242,23 @@ async function handleComponent(component: MessageComponentInteraction, source: C
             const settings = await getAutoModSettings(guild.id);
             await component.deferUpdate();
             await updateAutoModSettings(guild.id, { enabled: !settings.enabled });
-            await component.editReply(await buildAutoModHome(guild));
+            await component.editReply(await buildAutoModGeneral(guild));
             return;
         }
         if (component.customId === 'settings:automod:rules') {
             await component.update(await buildAutoModRules(guild));
+            return;
+        }
+        if (component.customId === 'settings:automod:general') {
+            await component.update(await buildAutoModGeneral(guild));
+            return;
+        }
+        if (component.customId === 'settings:automod:filters') {
+            await component.update(await buildAutoModFilters(guild));
+            return;
+        }
+        if (component.customId === 'settings:automod:sanctions-menu') {
+            await component.update(await buildAutoModSanctions(guild));
             return;
         }
         if (component.customId === 'settings:automod:home') {
@@ -265,14 +277,32 @@ async function handleComponent(component: MessageComponentInteraction, source: C
             const settings = await getAutoModSettings(guild.id);
             await component.deferUpdate();
             await updateAutoModSettings(guild.id, { allow_own_invites: !settings.allow_own_invites });
-            await component.editReply(await buildAutoModHome(guild));
+            await component.editReply(await buildAutoModGeneral(guild));
+            return;
+        }
+        if (component.customId === 'settings:moderation:hub') {
+            await component.update(await buildModerationHub(guild));
+            return;
+        }
+        if (component.customId === 'settings:moderation:automod') {
+            await component.update(await buildAutoModHome(guild));
+            return;
+        }
+        if (component.customId === 'settings:moderation:logs') {
+            await component.update(await buildModerationLogs(guild));
+            return;
+        }
+        if (component.customId === 'settings:moderation:clear-log') {
+            await component.deferUpdate();
+            await updateModerationChannel(guild.id, '');
+            await component.editReply(await buildModerationLogs(guild));
             return;
         }
         if (component.customId === 'settings:automod:observation') {
             const settings = await getAutoModSettings(guild.id);
             await component.deferUpdate();
             await updateAutoModSettings(guild.id, { observation_mode: !settings.observation_mode });
-            await component.editReply(await buildAutoModHome(guild));
+            await component.editReply(await buildAutoModGeneral(guild));
             return;
         }
         if (component.customId === 'settings:automod:thresholds') {
@@ -464,7 +494,7 @@ async function handleComponent(component: MessageComponentInteraction, source: C
         if (component.customId === 'settings:automod:log-channel') {
             await component.deferUpdate();
             await updateModerationChannel(guild.id, channelId);
-            await component.editReply(await buildAutoModHome(guild));
+            await component.editReply(await buildModerationLogs(guild));
             return;
         }
         if (component.customId === 'settings:automod:excluded-channels') {
@@ -615,13 +645,12 @@ async function buildOverview(interaction: ChatInputCommandInteraction, notice?: 
             { name: '📑 Logs serveur', value: formatChannel(guild, logs), inline: true },
             {
                 name: '🛡️ Modération',
-                value: `${automod.enabled ? '🟢 AutoMod actif' : '⚪ AutoMod désactivé'} · ${formatChannel(guild, moderation)}`,
-                inline: true
+                value: `${automod.enabled ? '🟢 AutoMod actif' : '⚪ AutoMod désactivé'} · ` +
+                    `journal ${formatChannel(guild, moderation)} · reports ${formatChannel(guild, reports)} · ` +
+                    `mute ${formatRole(guild, mute)}`,
+                inline: false
             },
             { name: '🎂 Anniversaires', value: formatChannel(guild, birthdays), inline: true },
-            { name: '🔇 Rôle de mute', value: formatRole(guild, mute), inline: true },
-            { name: '🚩 Salon des reports', value: formatChannel(guild, reports), inline: true },
-            { name: '📣 Rôle mentionné', value: formatOptionalRole(guild, reportRole), inline: true },
             { name: '🎫 Panneau de tickets', value: formatChannel(guild, tickets.ticket_panel_channel_id), inline: true },
             { name: '📁 Catégorie des tickets', value: formatChannel(guild, tickets.ticket_category_id), inline: true },
             { name: '🧾 Logs des tickets', value: formatChannel(guild, tickets.ticket_log_channel_id), inline: true },
@@ -648,9 +677,7 @@ async function buildOverview(interaction: ChatInputCommandInteraction, notice?: 
     const categories = new ActionRowBuilder<ButtonBuilder>().addComponents(
         new ButtonBuilder().setCustomId('settings:section:logs').setLabel('Logs').setEmoji('📑').setStyle(ButtonStyle.Secondary),
         new ButtonBuilder().setCustomId('settings:section:moderation').setLabel('Modération').setEmoji('🛡️').setStyle(ButtonStyle.Secondary),
-        new ButtonBuilder().setCustomId('settings:section:birthdays').setLabel('Anniversaires').setEmoji('🎂').setStyle(ButtonStyle.Secondary),
-        new ButtonBuilder().setCustomId('settings:section:mute').setLabel('Mute').setEmoji('🔇').setStyle(ButtonStyle.Secondary),
-        new ButtonBuilder().setCustomId('settings:section:reports').setLabel('Reports').setEmoji('🚩').setStyle(ButtonStyle.Secondary)
+        new ButtonBuilder().setCustomId('settings:section:birthdays').setLabel('Anniversaires').setEmoji('🎂').setStyle(ButtonStyle.Secondary)
     );
     const modules = new ActionRowBuilder<ButtonBuilder>().addComponents(
         new ButtonBuilder().setCustomId('settings:section:tickets').setLabel('Tickets').setEmoji('🎫').setStyle(ButtonStyle.Secondary),
@@ -694,7 +721,7 @@ async function buildSection(section: ConfigSection, guild: Guild) {
     if (section === 'xp') return buildXpHome(guild);
     if (section === 'invites') return buildInviteSection(guild);
     if (section === 'timezone') return buildTimezoneSection(guild);
-    if (section === 'moderation') return buildAutoModHome(guild);
+    if (section === 'moderation') return buildModerationHub(guild);
     const embed = createKeplerEmbed()
         .setColor(PANEL_COLOR)
         .setTitle(sectionLabel(section))
@@ -787,7 +814,7 @@ async function buildSection(section: ConfigSection, guild: Guild) {
                 new ActionRowBuilder<ButtonBuilder>().addComponents(
                     new ButtonBuilder().setCustomId('settings:clear-report-role').setLabel('Retirer le rôle').setStyle(ButtonStyle.Secondary),
                     new ButtonBuilder().setCustomId('settings:disable:reports').setLabel('Désactiver').setStyle(ButtonStyle.Danger),
-                    backButton()
+                    moderationBackButton()
                 )
             ]
         };
@@ -811,7 +838,7 @@ async function buildSection(section: ConfigSection, guild: Guild) {
                 new ActionRowBuilder<ButtonBuilder>().addComponents(
                     new ButtonBuilder().setCustomId('settings:create-mute').setLabel('Créer le rôle').setEmoji('➕').setStyle(ButtonStyle.Primary),
                     new ButtonBuilder().setCustomId('settings:disable:mute').setLabel('Utiliser les timeouts').setStyle(ButtonStyle.Danger),
-                    backButton()
+                    moderationBackButton()
                 )
             ]
         };
@@ -819,9 +846,7 @@ async function buildSection(section: ConfigSection, guild: Guild) {
 
     const configuredChannelId = section === 'logs'
         ? await getLogChannel(guild.id)
-        : section === 'moderation'
-            ? await getModerationChannel(guild.id)
-            : await getBirthdayChannel(guild.id);
+        : await getBirthdayChannel(guild.id);
     const select = new ChannelSelectMenuBuilder()
         .setCustomId(`settings:select:${section}`)
         .setPlaceholder('Choisir un salon textuel')
@@ -991,6 +1016,84 @@ async function buildInviteFields(guild: Guild) {
     };
 }
 
+async function buildModerationHub(guild: Guild) {
+    const [settings, moderationChannelId, muteRoleId, reportChannelId, reportRoleId] = await Promise.all([
+        getAutoModSettings(guild.id),
+        getModerationChannel(guild.id),
+        getMuteRole(guild.id),
+        getReportChannel(guild.id),
+        getReportRole(guild.id)
+    ]);
+    return {
+        content: '',
+        embeds: [
+            createKeplerEmbed(settings.enabled ? 'primary' : 'neutral')
+                .setTitle('Modération')
+                .setDescription(
+                    'Tous les outils de sécurité du serveur sont regroupés ici. ' +
+                    'Choisissez une rubrique pour modifier ses réglages.'
+                )
+                .addFields(
+                    {
+                        name: '🛡️ Auto-modération',
+                        value: settings.enabled
+                            ? `🟢 Active · ${settings.observation_mode ? 'observation' : 'sanctions actives'}`
+                            : '⚪ Désactivée',
+                        inline: true
+                    },
+                    { name: '⚖️ Sanctions et mute', value: formatRole(guild, muteRoleId), inline: true },
+                    {
+                        name: '🚩 Signalements',
+                        value: `${formatChannel(guild, reportChannelId)} · ${formatOptionalRole(guild, reportRoleId)}`,
+                        inline: true
+                    },
+                    { name: '🧾 Journal de modération', value: formatChannel(guild, moderationChannelId), inline: false }
+                )
+                .setFooter({ text: guild.name })
+        ],
+        components: [
+            new ActionRowBuilder<ButtonBuilder>().addComponents(
+                new ButtonBuilder().setCustomId('settings:moderation:automod').setLabel('Auto-modération').setEmoji('🛡️').setStyle(ButtonStyle.Primary),
+                new ButtonBuilder().setCustomId('settings:section:mute').setLabel('Sanctions et mute').setEmoji('⚖️').setStyle(ButtonStyle.Secondary),
+                new ButtonBuilder().setCustomId('settings:section:reports').setLabel('Signalements').setEmoji('🚩').setStyle(ButtonStyle.Secondary),
+                new ButtonBuilder().setCustomId('settings:moderation:logs').setLabel('Journal').setEmoji('🧾').setStyle(ButtonStyle.Secondary)
+            ),
+            new ActionRowBuilder<ButtonBuilder>().addComponents(backButton())
+        ]
+    };
+}
+
+async function buildModerationLogs(guild: Guild) {
+    const channelId = await getModerationChannel(guild.id);
+    const select = new ChannelSelectMenuBuilder()
+        .setCustomId('settings:automod:log-channel')
+        .setPlaceholder('Choisir le journal de modération')
+        .addChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement)
+        .setMinValues(1)
+        .setMaxValues(1);
+    if (channelId && guild.channels.cache.has(channelId)) select.setDefaultChannels(channelId);
+    return {
+        content: '',
+        embeds: [
+            createKeplerEmbed('primary')
+                .setTitle('Modération · Journal')
+                .setDescription(
+                    'Ce salon reçoit les sanctions manuelles, les détections AutoMod, ' +
+                    'les timeouts et les alertes anti-raid.'
+                )
+                .addFields({ name: 'Salon actuel', value: formatChannel(guild, channelId), inline: false })
+                .setFooter({ text: guild.name })
+        ],
+        components: [
+            new ActionRowBuilder<ChannelSelectMenuBuilder>().addComponents(select),
+            new ActionRowBuilder<ButtonBuilder>().addComponents(
+                new ButtonBuilder().setCustomId('settings:moderation:clear-log').setLabel('Retirer le salon').setStyle(ButtonStyle.Danger),
+                moderationBackButton()
+            )
+        ]
+    };
+}
+
 async function buildAutoModHome(guild: Guild) {
     const [settings, logChannelId, stats] = await Promise.all([
         getAutoModSettings(guild.id),
@@ -1007,12 +1110,6 @@ async function buildAutoModHome(guild: Guild) {
         settings.anti_keyword_enabled,
         settings.anti_raid_enabled
     ].filter(Boolean).length;
-    const logSelect = new ChannelSelectMenuBuilder()
-        .setCustomId('settings:automod:log-channel')
-        .setPlaceholder('Choisir le salon des logs de modération')
-        .addChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement)
-        .setMinValues(1)
-        .setMaxValues(1);
     const embed = createKeplerEmbed(settings.enabled ? 'primary' : 'neutral')
         .setTitle('Auto-modération')
         .setDescription(
@@ -1047,29 +1144,103 @@ async function buildAutoModHome(guild: Guild) {
         content: '',
         embeds: [embed],
         components: [
-            new ActionRowBuilder<ChannelSelectMenuBuilder>().addComponents(logSelect),
+            new ActionRowBuilder<ButtonBuilder>().addComponents(
+                new ButtonBuilder().setCustomId('settings:automod:general').setLabel('Général').setEmoji('⚙️').setStyle(ButtonStyle.Primary),
+                new ButtonBuilder().setCustomId('settings:automod:rules').setLabel('Protections').setEmoji('🛡️').setStyle(ButtonStyle.Primary),
+                new ButtonBuilder().setCustomId('settings:automod:filters').setLabel('Filtres et seuils').setEmoji('🎚️').setStyle(ButtonStyle.Secondary),
+                new ButtonBuilder().setCustomId('settings:automod:sanctions-menu').setLabel('Sanctions').setEmoji('⚖️').setStyle(ButtonStyle.Secondary),
+                new ButtonBuilder().setCustomId('settings:automod:exemptions').setLabel('Exemptions').setEmoji('🕊️').setStyle(ButtonStyle.Secondary)
+            ),
+            new ActionRowBuilder<ButtonBuilder>().addComponents(moderationBackButton())
+        ]
+    };
+}
+
+async function buildAutoModGeneral(guild: Guild) {
+    const settings = await getAutoModSettings(guild.id);
+    return {
+        content: '',
+        embeds: [
+            createKeplerEmbed(settings.enabled ? 'primary' : 'neutral')
+                .setTitle('AutoMod · Général')
+                .setDescription('Contrôlez l’état global du moteur et son comportement de déploiement.')
+                .addFields(
+                    { name: 'Moteur', value: settings.enabled ? '🟢 Actif' : '⚪ Désactivé', inline: true },
+                    { name: 'Mode', value: settings.observation_mode ? '👁️ Observation' : '⚖️ Sanctions actives', inline: true },
+                    {
+                        name: 'Invitations internes',
+                        value: settings.allow_own_invites ? '🟢 Autorisées' : '⚪ Bloquées',
+                        inline: true
+                    }
+                )
+                .setFooter({ text: guild.name })
+        ],
+        components: [
             new ActionRowBuilder<ButtonBuilder>().addComponents(
                 new ButtonBuilder()
                     .setCustomId('settings:automod:toggle')
-                    .setLabel(settings.enabled ? 'Désactiver' : 'Activer')
+                    .setLabel(settings.enabled ? 'Désactiver le moteur' : 'Activer le moteur')
                     .setStyle(settings.enabled ? ButtonStyle.Danger : ButtonStyle.Success),
-                new ButtonBuilder().setCustomId('settings:automod:rules').setLabel('Protections').setEmoji('🛡️').setStyle(ButtonStyle.Primary),
-                new ButtonBuilder().setCustomId('settings:automod:thresholds').setLabel('Seuils').setEmoji('🎚️').setStyle(ButtonStyle.Secondary),
-                new ButtonBuilder().setCustomId('settings:automod:action').setLabel('Sanctions').setEmoji('⚖️').setStyle(ButtonStyle.Secondary),
-                new ButtonBuilder().setCustomId('settings:automod:exemptions').setLabel('Exemptions').setEmoji('🕊️').setStyle(ButtonStyle.Secondary)
-            ),
-            new ActionRowBuilder<ButtonBuilder>().addComponents(
-                new ButtonBuilder().setCustomId('settings:automod:domains').setLabel('Domaines autorisés').setEmoji('🌐').setStyle(ButtonStyle.Secondary),
-                new ButtonBuilder().setCustomId('settings:automod:keywords').setLabel('Mots et regex').setEmoji('📝').setStyle(ButtonStyle.Secondary),
-                new ButtonBuilder()
-                    .setCustomId('settings:automod:own-invites')
-                    .setLabel(settings.allow_own_invites ? 'Invitations du serveur autorisées' : 'Toutes les invitations bloquées')
-                    .setStyle(settings.allow_own_invites ? ButtonStyle.Success : ButtonStyle.Secondary),
                 new ButtonBuilder()
                     .setCustomId('settings:automod:observation')
-                    .setLabel(settings.observation_mode ? 'Observation active' : 'Mode observation')
+                    .setLabel(settings.observation_mode ? 'Activer les sanctions' : 'Passer en observation')
                     .setStyle(settings.observation_mode ? ButtonStyle.Success : ButtonStyle.Secondary),
-                backButton()
+                new ButtonBuilder()
+                    .setCustomId('settings:automod:own-invites')
+                    .setLabel(settings.allow_own_invites ? 'Bloquer les invitations internes' : 'Autoriser les invitations internes')
+                    .setStyle(ButtonStyle.Secondary)
+            ),
+            new ActionRowBuilder<ButtonBuilder>().addComponents(autoModBackButton())
+        ]
+    };
+}
+
+async function buildAutoModFilters(guild: Guild) {
+    const settings = await getAutoModSettings(guild.id);
+    return {
+        content: '',
+        embeds: [
+            createKeplerEmbed('primary')
+                .setTitle('AutoMod · Filtres et seuils')
+                .setDescription('Personnalisez ce que Kepler accepte et les seuils déclenchant chaque protection.')
+                .addFields(
+                    { name: 'Domaines autorisés', value: String(settings.allowed_domains.length), inline: true },
+                    { name: 'Termes interdits', value: String(settings.blocked_keywords.length), inline: true },
+                    { name: 'Expressions régulières', value: String(settings.regex_patterns.length), inline: true }
+                )
+                .setFooter({ text: guild.name })
+        ],
+        components: [
+            new ActionRowBuilder<ButtonBuilder>().addComponents(
+                new ButtonBuilder().setCustomId('settings:automod:thresholds').setLabel('Seuils numériques').setEmoji('🎚️').setStyle(ButtonStyle.Primary),
+                new ButtonBuilder().setCustomId('settings:automod:domains').setLabel('Domaines autorisés').setEmoji('🌐').setStyle(ButtonStyle.Secondary),
+                new ButtonBuilder().setCustomId('settings:automod:keywords').setLabel('Mots et regex').setEmoji('📝').setStyle(ButtonStyle.Secondary),
+                autoModBackButton()
+            )
+        ]
+    };
+}
+
+async function buildAutoModSanctions(guild: Guild) {
+    const settings = await getAutoModSettings(guild.id);
+    return {
+        content: '',
+        embeds: [
+            createKeplerEmbed('warning')
+                .setTitle('AutoMod · Sanctions')
+                .setDescription('Définissez l’action générale, les paliers de récidive et les exceptions par règle.')
+                .addFields(
+                    { name: 'Action par défaut', value: settings.action, inline: true },
+                    { name: 'Paliers', value: `${settings.escalation_steps.length} configuré(s)`, inline: true },
+                    { name: 'Actions spécifiques', value: `${Object.keys(settings.rule_actions).length} règle(s)`, inline: true }
+                )
+                .setFooter({ text: guild.name })
+        ],
+        components: [
+            new ActionRowBuilder<ButtonBuilder>().addComponents(
+                new ButtonBuilder().setCustomId('settings:automod:action').setLabel('Action et progression').setEmoji('📈').setStyle(ButtonStyle.Primary),
+                new ButtonBuilder().setCustomId('settings:automod:rule-actions').setLabel('Actions par règle').setEmoji('⚖️').setStyle(ButtonStyle.Secondary),
+                autoModBackButton()
             )
         ]
     };
@@ -1527,7 +1698,7 @@ async function showAutoModThresholdsModal(component: ButtonInteraction, source: 
         caps_min_letters: caps![1],
         mention_limit: mentions
     });
-    await submission.editReply(await buildAutoModHome(source.guild!));
+    await submission.editReply(await buildAutoModFilters(source.guild!));
 }
 
 async function showAutoModActionModal(component: ButtonInteraction, source: ChatInputCommandInteraction) {
@@ -1578,7 +1749,7 @@ async function showAutoModActionModal(component: ButtonInteraction, source: Chat
         notify_user: notify === 'oui',
         escalation_steps: policy
     });
-    await submission.editReply(await buildAutoModHome(source.guild!));
+    await submission.editReply(await buildAutoModSanctions(source.guild!));
 }
 
 async function showAutoModKeywordsModal(component: ButtonInteraction, source: ChatInputCommandInteraction) {
@@ -1623,7 +1794,7 @@ async function showAutoModKeywordsModal(component: ButtonInteraction, source: Ch
         allowed_keywords: allowed,
         regex_patterns: regex
     });
-    await submission.editReply(await buildAutoModHome(source.guild!));
+    await submission.editReply(await buildAutoModFilters(source.guild!));
 }
 
 function parseEscalationPolicy(value: string): AutoModEscalationStep[] | null {
@@ -1668,7 +1839,7 @@ async function showAutoModRuleActionsModal(component: ButtonInteraction, source:
     }
     await submission.deferUpdate();
     await updateAutoModSettings(source.guildId!, { rule_actions: parsed });
-    await submission.editReply(await buildAutoModRules(source.guild!));
+    await submission.editReply(await buildAutoModSanctions(source.guild!));
 }
 
 function parseRuleActions(value: string) {
@@ -1717,7 +1888,7 @@ async function showAutoModDomainsModal(component: ButtonInteraction, source: Cha
     }
     await submission.deferUpdate();
     await updateAutoModSettings(source.guildId!, { allowed_domains: domains });
-    await submission.editReply(await buildAutoModHome(source.guild!));
+    await submission.editReply(await buildAutoModFilters(source.guild!));
 }
 
 function settingsTextInput(customId: string, label: string, value: string, placeholder: string, required = true) {
@@ -2259,6 +2430,22 @@ function formatSeconds(totalSeconds: number): string {
 
 function backButton(): ButtonBuilder {
     return new ButtonBuilder().setCustomId('settings:home').setLabel('Retour').setEmoji('↩️').setStyle(ButtonStyle.Secondary);
+}
+
+function moderationBackButton(): ButtonBuilder {
+    return new ButtonBuilder()
+        .setCustomId('settings:moderation:hub')
+        .setLabel('Retour à la modération')
+        .setEmoji('↩️')
+        .setStyle(ButtonStyle.Secondary);
+}
+
+function autoModBackButton(): ButtonBuilder {
+    return new ButtonBuilder()
+        .setCustomId('settings:automod:home')
+        .setLabel('Retour à l’AutoMod')
+        .setEmoji('↩️')
+        .setStyle(ButtonStyle.Secondary);
 }
 
 function xpBackButton(): ButtonBuilder {

--- a/commands/administration/settings.ts
+++ b/commands/administration/settings.ts
@@ -7,11 +7,16 @@ import {
     ChannelSelectMenuBuilder,
     ChannelType,
     type ChatInputCommandInteraction,
+    ContainerBuilder,
+    type EmbedBuilder,
+    MessageFlags,
     ModalBuilder,
     PermissionFlagsBits,
     RoleSelectMenuBuilder,
     SlashCommandBuilder,
     StringSelectMenuBuilder,
+    SeparatorBuilder,
+    TextDisplayBuilder,
     TextInputBuilder,
     TextInputStyle,
     type Guild,
@@ -85,6 +90,51 @@ type AutoModRuleKey =
 const PANEL_COLOR = KEPLER_COLORS.primary;
 const PANEL_TIMEOUT = 5 * 60 * 1000;
 
+type LegacySettingsView = {
+    content?: string;
+    embeds?: EmbedBuilder[];
+    components?: ActionRowBuilder<any>[];
+};
+
+function toComponentsV2(view: LegacySettingsView) {
+    const embed = view.embeds?.[0]?.toJSON();
+    const container = new ContainerBuilder().setAccentColor(embed?.color ?? PANEL_COLOR);
+    const heading = [
+        embed?.author?.name ? `-# ${embed.author.name.toUpperCase()}` : null,
+        embed?.title ? `## ${embed.title}` : null,
+        embed?.description || view.content || null
+    ].filter(Boolean).join('\n');
+
+    if (heading) container.addTextDisplayComponents(new TextDisplayBuilder().setContent(heading));
+
+    if (embed?.fields?.length) {
+        if (heading) container.addSeparatorComponents(new SeparatorBuilder().setDivider(true));
+        container.addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(
+                embed.fields.map(field => `**${field.name}**\n${field.value}`).join('\n\n')
+            )
+        );
+    }
+
+    if (view.components?.length) {
+        if (heading || embed?.fields?.length) {
+            container.addSeparatorComponents(new SeparatorBuilder().setDivider(true));
+        }
+        container.addActionRowComponents(...view.components);
+    }
+
+    const footer = embed?.footer?.text;
+    if (footer) {
+        container.addSeparatorComponents(new SeparatorBuilder().setDivider(false));
+        container.addTextDisplayComponents(new TextDisplayBuilder().setContent(`-# ${footer}`));
+    }
+
+    return {
+        components: [container],
+        flags: MessageFlags.IsComponentsV2 as MessageFlags.IsComponentsV2
+    };
+}
+
 export const data = new SlashCommandBuilder()
     .setName('settings')
     .setDescription('Ouvre le panneau de configuration du serveur')
@@ -102,7 +152,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 
     const response = await interaction.reply({
         ...(await buildOverview(interaction)),
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
         fetchReply: true
     });
 
@@ -136,7 +186,9 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 
     collector.on('end', async () => {
         try {
-            await interaction.editReply({ components: [] });
+            await interaction.editReply(toComponentsV2({
+                content: '⌛ Ce panneau de configuration a expiré. Relancez `/settings` pour continuer.'
+            }));
         } catch {
             // Le message éphémère peut déjà avoir été fermé.
         }
@@ -152,7 +204,7 @@ async function handleComponent(component: MessageComponentInteraction, source: C
             return;
         }
         if (component.customId === 'settings:close') {
-            await component.update({ content: 'Panneau de configuration fermé.', embeds: [], components: [] });
+            await component.update(toComponentsV2({ content: '✅ Panneau de configuration fermé.' }));
             return;
         }
         if (component.customId.startsWith('settings:section:')) {
@@ -629,7 +681,7 @@ async function handleComponent(component: MessageComponentInteraction, source: C
     }
 }
 
-async function buildOverview(interaction: ChatInputCommandInteraction, notice?: string) {
+async function buildOverviewLegacy(interaction: ChatInputCommandInteraction, notice?: string) {
     const guild = interaction.guild!;
     const dashboardUrl = getDashboardUrl(guild.id);
     const [logs, moderation, automod, birthdays, mute, reports, reportRole, tickets, xpSettings, xpRewards, inviteSettings, timezone] = await Promise.all([
@@ -737,7 +789,7 @@ function getDashboardUrl(guildId: string): string | null {
     }
 }
 
-async function buildTicketHome(guild: Guild) {
+async function buildTicketHomeLegacy(guild: Guild) {
     const config = await getTicketConfig(guild.id);
     const ready = Boolean(
         config.ticket_panel_channel_id && config.ticket_category_id &&
@@ -771,12 +823,12 @@ async function buildTicketHome(guild: Guild) {
     };
 }
 
-async function buildSection(section: ConfigSection, guild: Guild) {
-    if (section === 'xp') return buildXpHome(guild);
-    if (section === 'invites') return buildInviteSection(guild);
-    if (section === 'timezone') return buildTimezoneSection(guild);
-    if (section === 'moderation') return buildModerationHub(guild);
-    if (section === 'tickets') return buildTicketHome(guild);
+async function buildSectionLegacy(section: ConfigSection, guild: Guild) {
+    if (section === 'xp') return buildXpHomeLegacy(guild);
+    if (section === 'invites') return buildInviteSectionLegacy(guild);
+    if (section === 'timezone') return buildTimezoneSectionLegacy(guild);
+    if (section === 'moderation') return buildModerationHubLegacy(guild);
+    if (section === 'tickets') return buildTicketHomeLegacy(guild);
     const embed = createKeplerEmbed()
         .setColor(PANEL_COLOR)
         .setTitle(sectionLabel(section))
@@ -921,7 +973,7 @@ async function buildSection(section: ConfigSection, guild: Guild) {
     };
 }
 
-async function buildTimezoneSection(guild: Guild) {
+async function buildTimezoneSectionLegacy(guild: Guild) {
     const timezone = await getServerTimezone(guild.id);
     const now = new Date();
     const select = new StringSelectMenuBuilder()
@@ -958,7 +1010,7 @@ async function buildTimezoneSection(guild: Guild) {
     };
 }
 
-async function buildInviteSection(guild: Guild) {
+async function buildInviteSectionLegacy(guild: Guild) {
     const settings = await getInviteSettings(guild.id);
     return {
         content: '',
@@ -989,7 +1041,7 @@ async function buildInviteSection(guild: Guild) {
     };
 }
 
-async function buildInviteGeneral(guild: Guild) {
+async function buildInviteGeneralLegacy(guild: Guild) {
     const settings = await getInviteSettings(guild.id);
     return {
         content: '',
@@ -1005,7 +1057,7 @@ async function buildInviteGeneral(guild: Guild) {
     };
 }
 
-async function buildInviteChannels(guild: Guild) {
+async function buildInviteChannelsLegacy(guild: Guild) {
     const settings = await getInviteSettings(guild.id);
     const logChannel = new ChannelSelectMenuBuilder().setCustomId('settings:invites:log-channel')
         .setPlaceholder('Salon du journal d’invitations').addChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement).setMinValues(1).setMaxValues(1);
@@ -1030,7 +1082,7 @@ async function buildInviteChannels(guild: Guild) {
     };
 }
 
-async function buildInviteLogs(guild: Guild) {
+async function buildInviteLogsLegacy(guild: Guild) {
     const settings = await getInviteSettings(guild.id);
     return {
         content: '',
@@ -1046,7 +1098,7 @@ async function buildInviteLogs(guild: Guild) {
     };
 }
 
-async function buildInviteWelcome(guild: Guild) {
+async function buildInviteWelcomeLegacy(guild: Guild) {
     const settings = await getInviteSettings(guild.id);
     return {
         content: '',
@@ -1064,7 +1116,7 @@ async function buildInviteWelcome(guild: Guild) {
     };
 }
 
-async function buildInviteFields(guild: Guild) {
+async function buildInviteFieldsLegacy(guild: Guild) {
     const settings = await getInviteSettings(guild.id);
     const choices: Array<[InviteDisplayKey, string, string]> = [
         ['show_invite_code', 'Fin du lien', '🔗'],
@@ -1101,7 +1153,7 @@ async function buildInviteFields(guild: Guild) {
     };
 }
 
-async function buildModerationHub(guild: Guild) {
+async function buildModerationHubLegacy(guild: Guild) {
     const [settings, moderationChannelId, muteRoleId, reportChannelId, reportRoleId] = await Promise.all([
         getAutoModSettings(guild.id),
         getModerationChannel(guild.id),
@@ -1148,7 +1200,7 @@ async function buildModerationHub(guild: Guild) {
     };
 }
 
-async function buildModerationLogs(guild: Guild) {
+async function buildModerationLogsLegacy(guild: Guild) {
     const channelId = await getModerationChannel(guild.id);
     const select = new ChannelSelectMenuBuilder()
         .setCustomId('settings:automod:log-channel')
@@ -1179,7 +1231,7 @@ async function buildModerationLogs(guild: Guild) {
     };
 }
 
-async function buildAutoModHome(guild: Guild) {
+async function buildAutoModHomeLegacy(guild: Guild) {
     const [settings, logChannelId, stats] = await Promise.all([
         getAutoModSettings(guild.id),
         getModerationChannel(guild.id),
@@ -1241,7 +1293,7 @@ async function buildAutoModHome(guild: Guild) {
     };
 }
 
-async function buildAutoModGeneral(guild: Guild) {
+async function buildAutoModGeneralLegacy(guild: Guild) {
     const settings = await getAutoModSettings(guild.id);
     return {
         content: '',
@@ -1280,7 +1332,7 @@ async function buildAutoModGeneral(guild: Guild) {
     };
 }
 
-async function buildAutoModFilters(guild: Guild) {
+async function buildAutoModFiltersLegacy(guild: Guild) {
     const settings = await getAutoModSettings(guild.id);
     return {
         content: '',
@@ -1306,7 +1358,7 @@ async function buildAutoModFilters(guild: Guild) {
     };
 }
 
-async function buildAutoModSanctions(guild: Guild) {
+async function buildAutoModSanctionsLegacy(guild: Guild) {
     const settings = await getAutoModSettings(guild.id);
     return {
         content: '',
@@ -1331,7 +1383,7 @@ async function buildAutoModSanctions(guild: Guild) {
     };
 }
 
-async function buildAutoModRules(guild: Guild) {
+async function buildAutoModRulesLegacy(guild: Guild) {
     const settings = await getAutoModSettings(guild.id);
     const rules: Array<[AutoModRuleKey, string, string]> = [
         ['anti_link_enabled', 'Liens externes', '🌐'],
@@ -1371,7 +1423,7 @@ async function buildAutoModRules(guild: Guild) {
     };
 }
 
-async function buildAutoModExemptions(guild: Guild) {
+async function buildAutoModExemptionsLegacy(guild: Guild) {
     const settings = await getAutoModSettings(guild.id);
     const channels = new ChannelSelectMenuBuilder()
         .setCustomId('settings:automod:excluded-channels')
@@ -1412,7 +1464,7 @@ async function buildAutoModExemptions(guild: Guild) {
     };
 }
 
-async function buildXpHome(guild: Guild) {
+async function buildXpHomeLegacy(guild: Guild) {
     const [settings, rewards, boosts] = await Promise.all([
         getXpSettings(guild.id),
         getXpRewards(guild.id),
@@ -1453,7 +1505,7 @@ async function buildXpHome(guild: Guild) {
     };
 }
 
-async function buildXpGeneral(guild: Guild) {
+async function buildXpGeneralLegacy(guild: Guild) {
     const settings = await getXpSettings(guild.id);
     const levelChannelSelect = new ChannelSelectMenuBuilder()
         .setCustomId('settings:xp:level-channel')
@@ -1501,7 +1553,7 @@ async function buildXpGeneral(guild: Guild) {
     };
 }
 
-async function buildXpBoosts(guild: Guild) {
+async function buildXpBoostsLegacy(guild: Guild) {
     const [settings, boosts] = await Promise.all([
         getXpSettings(guild.id),
         getXpRoleBoosts(guild.id)
@@ -1549,7 +1601,7 @@ async function buildXpBoosts(guild: Guild) {
     };
 }
 
-async function buildXpRewards(guild: Guild) {
+async function buildXpRewardsLegacy(guild: Guild) {
     const rewards = await getXpRewards(guild.id);
     const components: ActionRowBuilder<any>[] = [
         new ActionRowBuilder<RoleSelectMenuBuilder>().addComponents(
@@ -1587,7 +1639,7 @@ async function buildXpRewards(guild: Guild) {
     };
 }
 
-async function buildXpExclusions(guild: Guild) {
+async function buildXpExclusionsLegacy(guild: Guild) {
     const settings = await getXpSettings(guild.id);
     const channelSelect = new ChannelSelectMenuBuilder()
         .setCustomId('settings:xp:excluded-channels')
@@ -1628,7 +1680,7 @@ async function buildXpExclusions(guild: Guild) {
     };
 }
 
-async function buildXpLogs(guild: Guild) {
+async function buildXpLogsLegacy(guild: Guild) {
     const settings = await getXpSettings(guild.id);
     const select = new ChannelSelectMenuBuilder()
         .setCustomId('settings:xp:log-channel')
@@ -1662,7 +1714,7 @@ async function buildXpLogs(guild: Guild) {
     };
 }
 
-function buildDisableConfirmation(section: ConfigSection) {
+function buildDisableConfirmationLegacy(section: ConfigSection) {
     const embed = createKeplerEmbed()
         .setColor(KEPLER_COLORS.danger)
         .setTitle('Confirmer la désactivation')
@@ -1674,7 +1726,7 @@ function buildDisableConfirmation(section: ConfigSection) {
     return { content: '', embeds: [embed], components: [row] };
 }
 
-function buildMuteCreationConfirmation() {
+function buildMuteCreationConfirmationLegacy() {
     const embed = createKeplerEmbed()
         .setColor(KEPLER_COLORS.warning)
         .setTitle('Créer un rôle de mute')
@@ -1684,6 +1736,110 @@ function buildMuteCreationConfirmation() {
         new ButtonBuilder().setCustomId('settings:section:mute').setLabel('Annuler').setStyle(ButtonStyle.Secondary)
     );
     return { content: '', embeds: [embed], components: [row] };
+}
+
+async function buildOverview(interaction: ChatInputCommandInteraction, notice?: string) {
+    return toComponentsV2(await buildOverviewLegacy(interaction, notice));
+}
+
+async function buildTicketHome(guild: Guild) {
+    return toComponentsV2(await buildTicketHomeLegacy(guild));
+}
+
+async function buildSection(section: ConfigSection, guild: Guild) {
+    return toComponentsV2(await buildSectionLegacy(section, guild));
+}
+
+async function buildTimezoneSection(guild: Guild) {
+    return toComponentsV2(await buildTimezoneSectionLegacy(guild));
+}
+
+async function buildInviteSection(guild: Guild) {
+    return toComponentsV2(await buildInviteSectionLegacy(guild));
+}
+
+async function buildInviteGeneral(guild: Guild) {
+    return toComponentsV2(await buildInviteGeneralLegacy(guild));
+}
+
+async function buildInviteChannels(guild: Guild) {
+    return toComponentsV2(await buildInviteChannelsLegacy(guild));
+}
+
+async function buildInviteLogs(guild: Guild) {
+    return toComponentsV2(await buildInviteLogsLegacy(guild));
+}
+
+async function buildInviteWelcome(guild: Guild) {
+    return toComponentsV2(await buildInviteWelcomeLegacy(guild));
+}
+
+async function buildInviteFields(guild: Guild) {
+    return toComponentsV2(await buildInviteFieldsLegacy(guild));
+}
+
+async function buildModerationHub(guild: Guild) {
+    return toComponentsV2(await buildModerationHubLegacy(guild));
+}
+
+async function buildModerationLogs(guild: Guild) {
+    return toComponentsV2(await buildModerationLogsLegacy(guild));
+}
+
+async function buildAutoModHome(guild: Guild) {
+    return toComponentsV2(await buildAutoModHomeLegacy(guild));
+}
+
+async function buildAutoModGeneral(guild: Guild) {
+    return toComponentsV2(await buildAutoModGeneralLegacy(guild));
+}
+
+async function buildAutoModFilters(guild: Guild) {
+    return toComponentsV2(await buildAutoModFiltersLegacy(guild));
+}
+
+async function buildAutoModSanctions(guild: Guild) {
+    return toComponentsV2(await buildAutoModSanctionsLegacy(guild));
+}
+
+async function buildAutoModRules(guild: Guild) {
+    return toComponentsV2(await buildAutoModRulesLegacy(guild));
+}
+
+async function buildAutoModExemptions(guild: Guild) {
+    return toComponentsV2(await buildAutoModExemptionsLegacy(guild));
+}
+
+async function buildXpHome(guild: Guild) {
+    return toComponentsV2(await buildXpHomeLegacy(guild));
+}
+
+async function buildXpGeneral(guild: Guild) {
+    return toComponentsV2(await buildXpGeneralLegacy(guild));
+}
+
+async function buildXpBoosts(guild: Guild) {
+    return toComponentsV2(await buildXpBoostsLegacy(guild));
+}
+
+async function buildXpRewards(guild: Guild) {
+    return toComponentsV2(await buildXpRewardsLegacy(guild));
+}
+
+async function buildXpExclusions(guild: Guild) {
+    return toComponentsV2(await buildXpExclusionsLegacy(guild));
+}
+
+async function buildXpLogs(guild: Guild) {
+    return toComponentsV2(await buildXpLogsLegacy(guild));
+}
+
+function buildDisableConfirmation(section: ConfigSection) {
+    return toComponentsV2(buildDisableConfirmationLegacy(section));
+}
+
+function buildMuteCreationConfirmation() {
+    return toComponentsV2(buildMuteCreationConfirmationLegacy());
 }
 
 async function updateChannelSection(section: ConfigSection, guildId: string, channelId: string) {

--- a/commands/administration/settings.ts
+++ b/commands/administration/settings.ts
@@ -702,7 +702,7 @@ async function handleComponent(component: MessageComponentInteraction, source: C
 async function buildOverviewLegacy(interaction: ChatInputCommandInteraction, notice?: string) {
     const guild = interaction.guild!;
     const dashboardUrl = getDashboardUrl(guild.id);
-    const [logs, moderation, automod, birthdays, mute, reports, tickets, xpSettings, xpRewards, inviteSettings, timezone] = await Promise.all([
+    const [logs, moderation, automod, birthdays, mute, reports, tickets, xpSettings, inviteSettings, timezone] = await Promise.all([
         getLogChannel(guild.id),
         getModerationChannel(guild.id),
         getAutoModSettings(guild.id),
@@ -711,7 +711,6 @@ async function buildOverviewLegacy(interaction: ChatInputCommandInteraction, not
         getReportChannel(guild.id),
         getTicketConfig(guild.id),
         getXpSettings(guild.id),
-        getXpRewards(guild.id),
         getInviteSettings(guild.id),
         getServerTimezone(guild.id)
     ]);
@@ -734,25 +733,26 @@ async function buildOverviewLegacy(interaction: ChatInputCommandInteraction, not
             {
                 name: '🛡️ Modération et sécurité',
                 value:
-                    `${statusIcon(automod.enabled)} AutoMod  ·  📑 Logs ${formatCompactChannel(guild, logs)}\n` +
-                    `🧾 Journal ${formatCompactChannel(guild, moderation)}  ·  🚩 Signalements ${formatCompactChannel(guild, reports)}\n` +
-                    `🔇 Mute ${formatCompactRole(guild, mute)}`,
+                    `${statusIcon(automod.enabled)} **AutoMod** — ${enabledLabel(automod.enabled)}\n` +
+                    `${configurationIcon(logs)} **Logs du serveur** — ${configurationLabel(logs)}\n` +
+                    `${configurationIcon(moderation)} **Journal de modération** — ${configurationLabel(moderation)}\n` +
+                    `${configurationIcon(reports)} **Signalements** — ${configurationLabel(reports)}\n` +
+                    `${mute ? '✅' : '◽'} **Sanctions longues** — ${mute ? 'Rôle configuré' : 'Timeouts Discord'}`,
                 inline: false
             },
             {
                 name: '👥 Communauté et engagement',
                 value:
-                    `🎂 Anniversaires ${formatCompactChannel(guild, birthdays)}\n` +
-                    `${statusIcon(xpSettings.enabled)} XP ${xpSettings.enabled ? `· ${xpSettings.cooldown_seconds}s · ${xpRewards.length} récompense(s)` : 'désactivée'}\n` +
-                    `${statusIcon(inviteSettings.enabled)} Invitations ${inviteSettings.enabled ? `· ${formatCompactChannel(guild, inviteSettings.log_channel_id)}` : 'désactivées'}`,
+                    `${configurationIcon(birthdays)} **Anniversaires** — ${configurationLabel(birthdays)}\n` +
+                    `${statusIcon(xpSettings.enabled)} **Expérience** — ${enabledLabel(xpSettings.enabled)}\n` +
+                    `${statusIcon(inviteSettings.enabled)} **Invitations** — ${enabledLabel(inviteSettings.enabled)}`,
                 inline: false
             },
             {
                 name: '🧰 Gestion du serveur',
                 value:
-                    `🎫 Tickets ${formatCompactChannel(guild, tickets.ticket_panel_channel_id)}  ·  📁 ${formatCompactChannel(guild, tickets.ticket_category_id)}\n` +
-                    `🧾 Journal ${formatCompactChannel(guild, tickets.ticket_log_channel_id)}  ·  🧑‍💻 ${formatCompactOptionalRole(guild, tickets.ticket_support_role_id)}\n` +
-                    `🌍 Fuseau \`${timezone}\``,
+                    `${ticketConfigurationIcon(tickets)} **Tickets** — ${ticketConfigurationLabel(tickets)}\n` +
+                    `✅ **Fuseau horaire** — \`${timezone}\``,
                 inline: false
             },
         )
@@ -2703,19 +2703,33 @@ function statusIcon(enabled: boolean): string {
     return enabled ? '✅' : '❌';
 }
 
-function formatCompactChannel(guild: Guild, channelId: string | null): string {
-    if (!channelId) return '❌ Non configuré';
-    return guild.channels.cache.has(channelId) ? `✅ <#${channelId}>` : '⚠️ Introuvable';
+function enabledLabel(enabled: boolean): string {
+    return enabled ? 'Activé' : 'Désactivé';
 }
 
-function formatCompactRole(guild: Guild, roleId: string | null): string {
-    if (!roleId) return '◽ Timeouts Discord';
-    return guild.roles.cache.has(roleId) ? `✅ <@&${roleId}>` : '⚠️ Introuvable';
+function configurationIcon(value: string | null): string {
+    return value ? '✅' : '❌';
 }
 
-function formatCompactOptionalRole(guild: Guild, roleId: string | null): string {
-    if (!roleId) return '❌ Aucun rôle';
-    return guild.roles.cache.has(roleId) ? `✅ <@&${roleId}>` : '⚠️ Introuvable';
+function configurationLabel(value: string | null): string {
+    return value ? 'Configuré' : 'Non configuré';
+}
+
+function isTicketConfigurationComplete(config: Awaited<ReturnType<typeof getTicketConfig>>): boolean {
+    return Boolean(
+        config.ticket_panel_channel_id &&
+        config.ticket_category_id &&
+        config.ticket_log_channel_id &&
+        config.ticket_support_role_id
+    );
+}
+
+function ticketConfigurationIcon(config: Awaited<ReturnType<typeof getTicketConfig>>): string {
+    return isTicketConfigurationComplete(config) ? '✅' : '⚠️';
+}
+
+function ticketConfigurationLabel(config: Awaited<ReturnType<typeof getTicketConfig>>): string {
+    return isTicketConfigurationComplete(config) ? 'Système prêt' : 'Configuration incomplète';
 }
 
 function formatSeconds(totalSeconds: number): string {

--- a/commands/administration/settings.ts
+++ b/commands/administration/settings.ts
@@ -94,6 +94,7 @@ type LegacySettingsView = {
     content?: string;
     embeds?: EmbedBuilder[];
     components?: ActionRowBuilder<any>[];
+    groupFieldsWithComponents?: boolean;
 };
 
 function toComponentsV2(view: LegacySettingsView) {
@@ -107,7 +108,19 @@ function toComponentsV2(view: LegacySettingsView) {
 
     if (heading) container.addTextDisplayComponents(new TextDisplayBuilder().setContent(heading));
 
-    if (embed?.fields?.length) {
+    if (embed?.fields?.length && view.groupFieldsWithComponents) {
+        if (heading) container.addSeparatorComponents(new SeparatorBuilder().setDivider(true));
+        embed.fields.forEach((field, index) => {
+            container.addTextDisplayComponents(
+                new TextDisplayBuilder().setContent(`### ${field.name}\n${field.value}`)
+            );
+            const row = view.components?.[index];
+            if (row) container.addActionRowComponents(row);
+            if (index < embed.fields!.length - 1) {
+                container.addSeparatorComponents(new SeparatorBuilder().setDivider(true));
+            }
+        });
+    } else if (embed?.fields?.length) {
         if (heading) container.addSeparatorComponents(new SeparatorBuilder().setDivider(true));
         container.addTextDisplayComponents(
             new TextDisplayBuilder().setContent(
@@ -116,11 +129,14 @@ function toComponentsV2(view: LegacySettingsView) {
         );
     }
 
-    if (view.components?.length) {
+    const remainingComponents = view.groupFieldsWithComponents
+        ? view.components?.slice(embed?.fields?.length ?? 0)
+        : view.components;
+    if (remainingComponents?.length) {
         if (heading || embed?.fields?.length) {
             container.addSeparatorComponents(new SeparatorBuilder().setDivider(true));
         }
-        container.addActionRowComponents(...view.components);
+        container.addActionRowComponents(...remainingComponents);
     }
 
     const footer = embed?.footer?.text;
@@ -668,7 +684,9 @@ async function handleComponent(component: MessageComponentInteraction, source: C
 
     if (component.isStringSelectMenu()) {
         await component.deferUpdate();
-        if (component.customId === 'settings:timezone:common') {
+        if (component.customId.startsWith('settings:navigate:')) {
+            await component.editReply(await buildSection(component.values[0] as ConfigSection, guild));
+        } else if (component.customId === 'settings:timezone:common') {
             await updateServerTimezone(guild.id, component.values[0]);
             await component.editReply(await buildTimezoneSection(guild));
         } else if (component.customId === 'settings:xp:remove-boost') {
@@ -684,14 +702,13 @@ async function handleComponent(component: MessageComponentInteraction, source: C
 async function buildOverviewLegacy(interaction: ChatInputCommandInteraction, notice?: string) {
     const guild = interaction.guild!;
     const dashboardUrl = getDashboardUrl(guild.id);
-    const [logs, moderation, automod, birthdays, mute, reports, reportRole, tickets, xpSettings, xpRewards, inviteSettings, timezone] = await Promise.all([
+    const [logs, moderation, automod, birthdays, mute, reports, tickets, xpSettings, xpRewards, inviteSettings, timezone] = await Promise.all([
         getLogChannel(guild.id),
         getModerationChannel(guild.id),
         getAutoModSettings(guild.id),
         getBirthdayChannel(guild.id),
         getMuteRole(guild.id),
         getReportChannel(guild.id),
-        getReportRole(guild.id),
         getTicketConfig(guild.id),
         getXpSettings(guild.id),
         getXpRewards(guild.id),
@@ -714,48 +731,61 @@ async function buildOverviewLegacy(interaction: ChatInputCommandInteraction, not
                     : 'Sélectionnez une catégorie pour modifier sa configuration.'
         )
         .addFields(
-            { name: '📑 Logs serveur', value: formatChannel(guild, logs), inline: true },
             {
-                name: '🛡️ Modération',
-                value: `${automod.enabled ? '🟢 AutoMod actif' : '⚪ AutoMod désactivé'} · ` +
-                    `journal ${formatChannel(guild, moderation)} · reports ${formatChannel(guild, reports)} · ` +
-                    `mute ${formatRole(guild, mute)}`,
+                name: '🛡️ Modération et sécurité',
+                value:
+                    `${statusIcon(automod.enabled)} AutoMod  ·  📑 Logs ${formatCompactChannel(guild, logs)}\n` +
+                    `🧾 Journal ${formatCompactChannel(guild, moderation)}  ·  🚩 Signalements ${formatCompactChannel(guild, reports)}\n` +
+                    `🔇 Mute ${formatCompactRole(guild, mute)}`,
                 inline: false
             },
-            { name: '🎂 Anniversaires', value: formatChannel(guild, birthdays), inline: true },
-            { name: '🎫 Panneau de tickets', value: formatChannel(guild, tickets.ticket_panel_channel_id), inline: true },
-            { name: '📁 Catégorie des tickets', value: formatChannel(guild, tickets.ticket_category_id), inline: true },
-            { name: '🧾 Logs des tickets', value: formatChannel(guild, tickets.ticket_log_channel_id), inline: true },
-            { name: '🧑‍💻 Rôle support', value: formatOptionalRole(guild, tickets.ticket_support_role_id), inline: true },
             {
-                name: '✨ Expérience',
-                value: xpSettings.enabled
-                    ? `🟢 Actif · ${xpSettings.cooldown_seconds}s · ${xpRewards.length} récompense(s)`
-                    : '⚪ Désactivé',
-                inline: true
+                name: '👥 Communauté et engagement',
+                value:
+                    `🎂 Anniversaires ${formatCompactChannel(guild, birthdays)}\n` +
+                    `${statusIcon(xpSettings.enabled)} XP ${xpSettings.enabled ? `· ${xpSettings.cooldown_seconds}s · ${xpRewards.length} récompense(s)` : 'désactivée'}\n` +
+                    `${statusIcon(inviteSettings.enabled)} Invitations ${inviteSettings.enabled ? `· ${formatCompactChannel(guild, inviteSettings.log_channel_id)}` : 'désactivées'}`,
+                inline: false
             },
             {
-                name: '🔗 Invitations',
-                value: inviteSettings.enabled
-                    ? `🟢 Actif · logs ${formatChannel(guild, inviteSettings.log_channel_id)}`
-                    : '⚪ Désactivé',
-                inline: true
+                name: '🧰 Gestion du serveur',
+                value:
+                    `🎫 Tickets ${formatCompactChannel(guild, tickets.ticket_panel_channel_id)}  ·  📁 ${formatCompactChannel(guild, tickets.ticket_category_id)}\n` +
+                    `🧾 Journal ${formatCompactChannel(guild, tickets.ticket_log_channel_id)}  ·  🧑‍💻 ${formatCompactOptionalRole(guild, tickets.ticket_support_role_id)}\n` +
+                    `🌍 Fuseau \`${timezone}\``,
+                inline: false
             },
-            { name: '🌍 Fuseau horaire', value: `\`${timezone}\``, inline: true }
         )
         .setFooter({ text: 'Panneau privé • expiration dans 5 minutes' })
         .setTimestamp();
 
-    const categories = new ActionRowBuilder<ButtonBuilder>().addComponents(
-        new ButtonBuilder().setCustomId('settings:section:logs').setLabel('Logs').setEmoji('📑').setStyle(ButtonStyle.Secondary),
-        new ButtonBuilder().setCustomId('settings:section:moderation').setLabel('Modération').setEmoji('🛡️').setStyle(ButtonStyle.Secondary),
-        new ButtonBuilder().setCustomId('settings:section:birthdays').setLabel('Anniversaires').setEmoji('🎂').setStyle(ButtonStyle.Secondary)
+    const moderationMenu = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+        new StringSelectMenuBuilder()
+            .setCustomId('settings:navigate:moderation')
+            .setPlaceholder('Configurer la modération et la sécurité')
+            .addOptions(
+                { label: 'Modération', description: 'AutoMod, journaux, mute et signalements', value: 'moderation', emoji: '🛡️' },
+                { label: 'Logs du serveur', description: 'Événements généraux du serveur', value: 'logs', emoji: '📑' }
+            )
     );
-    const modules = new ActionRowBuilder<ButtonBuilder>().addComponents(
-        new ButtonBuilder().setCustomId('settings:section:tickets').setLabel('Tickets').setEmoji('🎫').setStyle(ButtonStyle.Secondary),
-        new ButtonBuilder().setCustomId('settings:section:xp').setLabel('Expérience').setEmoji('✨').setStyle(ButtonStyle.Secondary),
-        new ButtonBuilder().setCustomId('settings:section:invites').setLabel('Invitations').setEmoji('🔗').setStyle(ButtonStyle.Secondary),
-        new ButtonBuilder().setCustomId('settings:section:timezone').setLabel('Fuseau').setEmoji('🌍').setStyle(ButtonStyle.Secondary)
+    const communityMenu = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+        new StringSelectMenuBuilder()
+            .setCustomId('settings:navigate:community')
+            .setPlaceholder('Configurer la communauté et l’engagement')
+            .addOptions(
+                { label: 'Anniversaires', description: 'Salon des annonces d’anniversaire', value: 'birthdays', emoji: '🎂' },
+                { label: 'Expérience', description: 'Niveaux, récompenses et boosts', value: 'xp', emoji: '✨' },
+                { label: 'Invitations', description: 'Suivi des liens et arrivées', value: 'invites', emoji: '🔗' }
+            )
+    );
+    const serverMenu = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+        new StringSelectMenuBuilder()
+            .setCustomId('settings:navigate:server')
+            .setPlaceholder('Configurer les outils du serveur')
+            .addOptions(
+                { label: 'Tickets', description: 'Panneau, accès et apparence', value: 'tickets', emoji: '🎫' },
+                { label: 'Fuseau horaire', description: 'Dates et planifications', value: 'timezone', emoji: '🌍' }
+            )
     );
     const actions = new ActionRowBuilder<ButtonBuilder>();
     if (dashboardUrl) {
@@ -772,7 +802,12 @@ async function buildOverviewLegacy(interaction: ChatInputCommandInteraction, not
         new ButtonBuilder().setCustomId('settings:close').setEmoji('✖️').setStyle(ButtonStyle.Secondary)
     );
 
-    return { content: '', embeds: [embed], components: [categories, modules, actions] };
+    return {
+        content: '',
+        embeds: [embed],
+        components: [moderationMenu, communityMenu, serverMenu, actions],
+        groupFieldsWithComponents: true
+    };
 }
 
 function getDashboardUrl(guildId: string): string | null {
@@ -2662,6 +2697,25 @@ function formatRole(guild: Guild, roleId: string | null): string {
 function formatOptionalRole(guild: Guild, roleId: string | null): string {
     if (!roleId) return '⚪ Aucun rôle';
     return guild.roles.cache.has(roleId) ? `🟢 <@&${roleId}>` : '🟠 Rôle introuvable';
+}
+
+function statusIcon(enabled: boolean): string {
+    return enabled ? '✅' : '❌';
+}
+
+function formatCompactChannel(guild: Guild, channelId: string | null): string {
+    if (!channelId) return '❌ Non configuré';
+    return guild.channels.cache.has(channelId) ? `✅ <#${channelId}>` : '⚠️ Introuvable';
+}
+
+function formatCompactRole(guild: Guild, roleId: string | null): string {
+    if (!roleId) return '◽ Timeouts Discord';
+    return guild.roles.cache.has(roleId) ? `✅ <@&${roleId}>` : '⚠️ Introuvable';
+}
+
+function formatCompactOptionalRole(guild: Guild, roleId: string | null): string {
+    if (!roleId) return '❌ Aucun rôle';
+    return guild.roles.cache.has(roleId) ? `✅ <@&${roleId}>` : '⚠️ Introuvable';
 }
 
 function formatSeconds(totalSeconds: number): string {

--- a/commands/general/invitations.ts
+++ b/commands/general/invitations.ts
@@ -1,12 +1,26 @@
 import {
+    type ActionRowBuilder,
+    type ButtonBuilder,
     type ChatInputCommandInteraction,
-    SlashCommandBuilder
+    ContainerBuilder,
+    type InteractionEditReplyOptions,
+    MessageFlags,
+    SectionBuilder,
+    SeparatorBuilder,
+    SlashCommandBuilder,
+    TextDisplayBuilder,
+    ThumbnailBuilder
 } from 'discord.js';
-import { createKeplerEmbed, KEPLER_MESSAGES, setRequesterFooter } from '../../utils/theme.ts';
+import { KEPLER_COLORS, KEPLER_MESSAGES } from '../../utils/theme.ts';
 import {
     getInviteLeaderboard,
     getInviteMemberStats
 } from '../../utils/invites/service.ts';
+import {
+    attachLeaderboardPagination,
+    leaderboardControls,
+    LEADERBOARD_PAGE_SIZE
+} from '../../utils/leaderboardPagination.ts';
 
 export const data = new SlashCommandBuilder()
     .setName('invitations')
@@ -25,46 +39,129 @@ export const data = new SlashCommandBuilder()
                     .setDescription('Membre à consulter')
                     .setRequired(false)));
 
+function inviteMessage(
+    container: ContainerBuilder,
+    controls?: ActionRowBuilder<ButtonBuilder>
+): InteractionEditReplyOptions {
+    return {
+        components: controls ? [container, controls] : [container],
+        flags: MessageFlags.IsComponentsV2,
+        allowedMentions: { parse: [] }
+    };
+}
+
+function requesterFooter(interaction: ChatInputCommandInteraction) {
+    const timestamp = Math.floor(Date.now() / 1000);
+    return new TextDisplayBuilder().setContent(
+        `-# ${interaction.guild!.name} • Demandé par ${interaction.user.username} • <t:${timestamp}:R>`
+    );
+}
+
 export async function execute(interaction: ChatInputCommandInteraction) {
     if (!interaction.guild) {
         await interaction.reply({ content: KEPLER_MESSAGES.guildOnly, ephemeral: true });
         return;
     }
     await interaction.deferReply();
-    await interaction.client.inviteManager?.synchronizeGuild(interaction.guild);
-
-    if (interaction.options.getSubcommand() === 'classement') {
-        const leaderboard = await getInviteLeaderboard(interaction.guild.id);
-        const description = leaderboard.length
-            ? leaderboard.map((entry, index) =>
-                `**${index + 1}.** <@${entry.inviter_id}> — **${entry.invite_count}** utilisation(s)`
-            ).join('\n')
-            : 'Aucune invitation active attribuable pour le moment.';
-        const embed = setRequesterFooter(
-            createKeplerEmbed('primary')
-                .setTitle('Classement des invitations')
-                .setDescription(description),
-            interaction.user,
-            interaction.guild.name
-        );
-        await interaction.editReply({ embeds: [embed] });
-        return;
+    try {
+        await (interaction.client as any).inviteManager?.synchronizeGuild(interaction.guild);
+        if (interaction.options.getSubcommand() === 'classement') {
+            await showLeaderboard(interaction);
+        } else {
+            await showMember(interaction);
+        }
+    } catch (error) {
+        console.error('[Invitations] Erreur commande:', error);
+        await interaction.editReply(inviteMessage(
+            new ContainerBuilder()
+                .setAccentColor(KEPLER_COLORS.danger)
+                .addTextDisplayComponents(
+                    new TextDisplayBuilder().setContent(KEPLER_MESSAGES.unexpectedError)
+                )
+        ));
     }
+}
 
-    const user = interaction.options.getUser('utilisateur') ?? interaction.user;
-    const stats = await getInviteMemberStats(interaction.guild.id, user.id);
-    const embed = setRequesterFooter(
-        createKeplerEmbed('primary')
-            .setTitle(`Invitations de ${user.username}`)
-            .setThumbnail(user.displayAvatarURL({ forceStatic: false }))
-            .addFields(
-                { name: 'Utilisations attribuées', value: String(stats.total_invites), inline: true },
-                { name: 'Arrivées suivies', value: String(stats.tracked_invites), inline: true },
-                { name: 'Toujours présentes', value: String(stats.active_members), inline: true },
-                { name: 'Départs suivis', value: String(stats.tracked_invites - stats.active_members), inline: true }
-            ),
-        interaction.user,
-        interaction.guild.name
+async function showLeaderboard(interaction: ChatInputCommandInteraction) {
+    const leaderboard = await getInviteLeaderboard(interaction.guildId!, 25);
+    const totalPages = Math.max(1, Math.ceil(leaderboard.length / LEADERBOARD_PAGE_SIZE));
+    const medals = ['🥇', '🥈', '🥉'];
+    const renderPage = (page: number, disabled = false) => {
+        const start = page * LEADERBOARD_PAGE_SIZE;
+        const rows = leaderboard.slice(start, start + LEADERBOARD_PAGE_SIZE).map((entry, index) => {
+            const position = start + index;
+            const marker = medals[position] ?? `**${position + 1}.**`;
+            return `${marker} <@${entry.inviter_id}> — **${entry.invite_count}** invitation(s)`;
+        });
+        const headingContent = new TextDisplayBuilder().setContent(
+            `-# KEPLER • INVITATIONS\n## Classement des invitations\n` +
+            `${leaderboard.length} inviteur(s) classé(s).`
+        );
+        const iconUrl = interaction.guild!.iconURL({ forceStatic: true });
+        const container = new ContainerBuilder().setAccentColor(KEPLER_COLORS.primary);
+        if (iconUrl) {
+            container.addSectionComponents(
+                new SectionBuilder()
+                    .addTextDisplayComponents(headingContent)
+                    .setThumbnailAccessory(new ThumbnailBuilder().setURL(iconUrl))
+            );
+        } else {
+            container.addTextDisplayComponents(headingContent);
+        }
+        container
+            .addSeparatorComponents(new SeparatorBuilder().setDivider(true))
+            .addTextDisplayComponents(
+                new TextDisplayBuilder().setContent(
+                    rows.join('\n') || 'Aucune invitation active attribuable pour le moment.'
+                )
+            )
+            .addSeparatorComponents(new SeparatorBuilder().setDivider(false))
+            .addTextDisplayComponents(requesterFooter(interaction));
+        return inviteMessage(
+            container,
+            totalPages > 1
+                ? leaderboardControls('invitations:leaderboard', page, totalPages, disabled)
+                : undefined
+        );
+    };
+
+    const response = await interaction.editReply(renderPage(0));
+    attachLeaderboardPagination(
+        interaction,
+        response,
+        'invitations:leaderboard',
+        totalPages,
+        renderPage
     );
-    await interaction.editReply({ embeds: [embed] });
+}
+
+async function showMember(interaction: ChatInputCommandInteraction) {
+    const user = interaction.options.getUser('utilisateur') ?? interaction.user;
+    const stats = await getInviteMemberStats(interaction.guildId!, user.id);
+    const departures = Math.max(0, stats.tracked_invites - stats.active_members);
+    const section = new SectionBuilder()
+        .addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(
+                `-# KEPLER • INVITATIONS\n## Invitations de ${user.username}\n` +
+                'Activité attribuée à ce membre sur le serveur.'
+            )
+        )
+        .setThumbnailAccessory(
+            new ThumbnailBuilder().setURL(user.displayAvatarURL({ forceStatic: true }))
+        );
+    const container = new ContainerBuilder()
+        .setAccentColor(KEPLER_COLORS.primary)
+        .addSectionComponents(section)
+        .addSeparatorComponents(new SeparatorBuilder().setDivider(true))
+        .addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(
+                `**Utilisations attribuées** — ${stats.total_invites}\n` +
+                `**Arrivées suivies** — ${stats.tracked_invites}\n` +
+                `**Toujours présentes** — ${stats.active_members}\n` +
+                `**Départs suivis** — ${departures}`
+            )
+        )
+        .addSeparatorComponents(new SeparatorBuilder().setDivider(false))
+        .addTextDisplayComponents(requesterFooter(interaction));
+    await interaction.editReply(inviteMessage(container));
 }

--- a/commands/general/xp.ts
+++ b/commands/general/xp.ts
@@ -1,6 +1,12 @@
 import {
+    ContainerBuilder,
+    MessageFlags,
+    SeparatorBuilder,
+    SectionBuilder,
     type ChatInputCommandInteraction,
-    SlashCommandBuilder
+    SlashCommandBuilder,
+    TextDisplayBuilder,
+    ThumbnailBuilder
 } from 'discord.js';
 import {
     getXpLeaderboard,
@@ -10,10 +16,24 @@ import {
     xpProgress
 } from '../../utils/xp/system.ts';
 import {
-    createKeplerEmbed,
+    KEPLER_COLORS,
     KEPLER_MESSAGES,
-    setRequesterFooter
 } from '../../utils/theme.ts';
+
+function xpMessage(container: ContainerBuilder) {
+    return {
+        components: [container],
+        flags: MessageFlags.IsComponentsV2 as MessageFlags.IsComponentsV2
+    };
+}
+
+function xpContainer(tone: keyof typeof KEPLER_COLORS = 'primary') {
+    return new ContainerBuilder().setAccentColor(KEPLER_COLORS[tone]);
+}
+
+function requesterFooter(interaction: ChatInputCommandInteraction) {
+    return new TextDisplayBuilder().setContent(`-# Demandé par ${interaction.user.username}`);
+}
 
 export const data = new SlashCommandBuilder()
     .setName('xp')
@@ -43,7 +63,11 @@ export async function execute(interaction: ChatInputCommandInteraction) {
         }
     } catch (error) {
         console.error('[XP] Erreur commande:', error);
-        await interaction.editReply({ content: KEPLER_MESSAGES.unexpectedError });
+        await interaction.editReply(xpMessage(
+            xpContainer('danger').addTextDisplayComponents(
+                new TextDisplayBuilder().setContent(KEPLER_MESSAGES.unexpectedError)
+            )
+        ));
     }
 }
 
@@ -52,47 +76,60 @@ async function showProfile(interaction: ChatInputCommandInteraction) {
     const profile = await getXpProfile(interaction.guildId!, user.id);
 
     if (!profile) {
-        await interaction.editReply({
-            embeds: [
-                createKeplerEmbed('neutral')
-                    .setTitle(`Profil XP de ${user.username}`)
-                    .setDescription('Ce membre n’a pas encore gagné d’XP sur ce serveur.')
-                    .setThumbnail(user.displayAvatarURL({ forceStatic: true }))
-            ]
-        });
+        const section = new SectionBuilder()
+            .addTextDisplayComponents(
+                new TextDisplayBuilder().setContent(
+                    `-# KEPLER • PROGRESSION XP\n## Profil de ${user.username}\n` +
+                    'Ce membre n’a pas encore gagné d’XP sur ce serveur.'
+                )
+            )
+            .setThumbnailAccessory(
+                new ThumbnailBuilder().setURL(user.displayAvatarURL({ forceStatic: true }))
+            );
+        await interaction.editReply(xpMessage(
+            xpContainer('neutral')
+                .addSectionComponents(section)
+                .addSeparatorComponents(new SeparatorBuilder().setDivider(false))
+                .addTextDisplayComponents(requesterFooter(interaction))
+        ));
         return;
     }
 
     const progress = xpProgress(profile.xp);
     const rank = await getXpRank(interaction.guildId!, profile.xp);
-    const embed = setRequesterFooter(
-        createKeplerEmbed('primary')
-            .setTitle(`Progression de ${user.username}`)
-            .setThumbnail(user.displayAvatarURL({ forceStatic: true }))
-            .setDescription(
-                `**Niveau ${progress.level}** · Rang **#${rank}**\n` +
-                `${progressBar(progress.percentage)} **${progress.percentage}%**`
+    const section = new SectionBuilder()
+        .addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(
+                `-# KEPLER • PROGRESSION XP\n## Progression de ${user.username}\n` +
+                `**Niveau ${progress.level}**  •  Rang **#${rank}**`
             )
-            .addFields(
-                {
-                    name: 'Progression',
-                    value: `${progress.current.toLocaleString('fr-FR')} / ${progress.required.toLocaleString('fr-FR')} XP`,
-                    inline: true
-                },
-                {
-                    name: 'XP total',
-                    value: profile.xp.toLocaleString('fr-FR'),
-                    inline: true
-                },
-                {
-                    name: 'Messages récompensés',
-                    value: profile.message_count.toLocaleString('fr-FR'),
-                    inline: true
-                }
-            ),
-        interaction.user
-    );
-    await interaction.editReply({ embeds: [embed] });
+        )
+        .setThumbnailAccessory(
+            new ThumbnailBuilder().setURL(user.displayAvatarURL({ forceStatic: true }))
+        );
+    const bar = progressBar(progress.percentage, 10);
+    const container = xpContainer('primary')
+        .addSectionComponents(section)
+        .addSeparatorComponents(new SeparatorBuilder().setDivider(true))
+        .addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(
+                `### Niveau ${progress.level} → ${progress.level + 1}\n` +
+                `\`${bar}\` **${progress.percentage}%**\n` +
+                `${progress.current.toLocaleString('fr-FR')} / ${progress.required.toLocaleString('fr-FR')} XP`
+            )
+        )
+        .addSeparatorComponents(new SeparatorBuilder().setDivider(false))
+        .addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(
+                `**XP total**\n${profile.xp.toLocaleString('fr-FR')}\n\n` +
+                `**Messages récompensés**\n${profile.message_count.toLocaleString('fr-FR')}`
+            )
+        )
+        .addSeparatorComponents(new SeparatorBuilder().setDivider(false))
+        .addTextDisplayComponents(
+            requesterFooter(interaction)
+        );
+    await interaction.editReply(xpMessage(container));
 }
 
 async function showLeaderboard(interaction: ChatInputCommandInteraction) {
@@ -103,12 +140,24 @@ async function showLeaderboard(interaction: ChatInputCommandInteraction) {
         return `${marker} <@${profile.user_id}> — niveau **${profile.level}** · ${profile.xp.toLocaleString('fr-FR')} XP`;
     });
 
-    const embed = setRequesterFooter(
-        createKeplerEmbed('primary')
-            .setTitle(`Classement XP · ${interaction.guild!.name}`)
-            .setDescription(rows.join('\n') || KEPLER_MESSAGES.noData)
-            .setThumbnail(interaction.guild!.iconURL({ forceStatic: true })),
-        interaction.user
-    );
-    await interaction.editReply({ embeds: [embed] });
+    const heading = new SectionBuilder()
+        .addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(
+                `-# KEPLER • CLASSEMENT XP\n## ${interaction.guild!.name}\n` +
+                'Les dix membres ayant accumulé le plus d’expérience.'
+            )
+        );
+    const iconUrl = interaction.guild!.iconURL({ forceStatic: true });
+    if (iconUrl) heading.setThumbnailAccessory(new ThumbnailBuilder().setURL(iconUrl));
+    const container = xpContainer('primary')
+        .addSectionComponents(heading)
+        .addSeparatorComponents(new SeparatorBuilder().setDivider(true))
+        .addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(rows.join('\n') || KEPLER_MESSAGES.noData)
+        )
+        .addSeparatorComponents(new SeparatorBuilder().setDivider(false))
+        .addTextDisplayComponents(
+            requesterFooter(interaction)
+        );
+    await interaction.editReply(xpMessage(container));
 }

--- a/commands/general/xp.ts
+++ b/commands/general/xp.ts
@@ -1,5 +1,8 @@
 import {
+    type ActionRowBuilder,
+    type ButtonBuilder,
     ContainerBuilder,
+    type InteractionEditReplyOptions,
     MessageFlags,
     SeparatorBuilder,
     SectionBuilder,
@@ -19,11 +22,20 @@ import {
     KEPLER_COLORS,
     KEPLER_MESSAGES,
 } from '../../utils/theme.ts';
+import {
+    attachLeaderboardPagination,
+    leaderboardControls,
+    LEADERBOARD_PAGE_SIZE
+} from '../../utils/leaderboardPagination.ts';
 
-function xpMessage(container: ContainerBuilder) {
+function xpMessage(
+    container: ContainerBuilder,
+    controls?: ActionRowBuilder<ButtonBuilder>
+): InteractionEditReplyOptions {
     return {
-        components: [container],
-        flags: MessageFlags.IsComponentsV2 as MessageFlags.IsComponentsV2
+        components: controls ? [container, controls] : [container],
+        flags: MessageFlags.IsComponentsV2,
+        allowedMentions: { parse: [] }
     };
 }
 
@@ -136,36 +148,45 @@ async function showProfile(interaction: ChatInputCommandInteraction) {
 }
 
 async function showLeaderboard(interaction: ChatInputCommandInteraction) {
-    const profiles = await getXpLeaderboard(interaction.guildId!, 10);
+    const profiles = await getXpLeaderboard(interaction.guildId!, 100);
     const medals = ['🥇', '🥈', '🥉'];
-    const rows = profiles.map((profile, index) => {
-        const marker = medals[index] ?? `**${index + 1}.**`;
-        return `${marker} <@${profile.user_id}> — niveau **${profile.level}** · ${profile.xp.toLocaleString('fr-FR')} XP`;
-    });
-
-    const headingContent = new TextDisplayBuilder().setContent(
-        `-# KEPLER • CLASSEMENT XP\n## ${interaction.guild!.name}\n` +
-        'Les dix membres ayant accumulé le plus d’expérience.'
-    );
-    const iconUrl = interaction.guild!.iconURL({ forceStatic: true });
-    const container = xpContainer('primary');
-    if (iconUrl) {
-        container.addSectionComponents(
-            new SectionBuilder()
-                .addTextDisplayComponents(headingContent)
-                .setThumbnailAccessory(new ThumbnailBuilder().setURL(iconUrl))
+    const totalPages = Math.max(1, Math.ceil(profiles.length / LEADERBOARD_PAGE_SIZE));
+    const renderPage = (page: number, disabled = false) => {
+        const start = page * LEADERBOARD_PAGE_SIZE;
+        const rows = profiles.slice(start, start + LEADERBOARD_PAGE_SIZE).map((profile, index) => {
+            const position = start + index;
+            const marker = medals[position] ?? `**${position + 1}.**`;
+            return `${marker} <@${profile.user_id}> — niveau **${profile.level}** · ${profile.xp.toLocaleString('fr-FR')} XP`;
+        });
+        const headingContent = new TextDisplayBuilder().setContent(
+            `-# KEPLER • CLASSEMENT XP\n## ${interaction.guild!.name}\n` +
+            `${profiles.length} membre(s) classé(s).`
         );
-    } else {
-        container.addTextDisplayComponents(headingContent);
-    }
-    container
-        .addSeparatorComponents(new SeparatorBuilder().setDivider(true))
-        .addTextDisplayComponents(
-            new TextDisplayBuilder().setContent(rows.join('\n') || KEPLER_MESSAGES.noData)
-        )
-        .addSeparatorComponents(new SeparatorBuilder().setDivider(false))
-        .addTextDisplayComponents(
-            requesterFooter(interaction)
+        const iconUrl = interaction.guild!.iconURL({ forceStatic: true });
+        const container = xpContainer('primary');
+        if (iconUrl) {
+            container.addSectionComponents(
+                new SectionBuilder()
+                    .addTextDisplayComponents(headingContent)
+                    .setThumbnailAccessory(new ThumbnailBuilder().setURL(iconUrl))
+            );
+        } else {
+            container.addTextDisplayComponents(headingContent);
+        }
+        container
+            .addSeparatorComponents(new SeparatorBuilder().setDivider(true))
+            .addTextDisplayComponents(
+                new TextDisplayBuilder().setContent(rows.join('\n') || KEPLER_MESSAGES.noData)
+            )
+            .addSeparatorComponents(new SeparatorBuilder().setDivider(false))
+            .addTextDisplayComponents(requesterFooter(interaction));
+        return xpMessage(
+            container,
+            totalPages > 1
+                ? leaderboardControls('xp:leaderboard', page, totalPages, disabled)
+                : undefined
         );
-    await interaction.editReply(xpMessage(container));
+    };
+    const response = await interaction.editReply(renderPage(0));
+    attachLeaderboardPagination(interaction, response, 'xp:leaderboard', totalPages, renderPage);
 }

--- a/commands/general/xp.ts
+++ b/commands/general/xp.ts
@@ -143,17 +143,22 @@ async function showLeaderboard(interaction: ChatInputCommandInteraction) {
         return `${marker} <@${profile.user_id}> — niveau **${profile.level}** · ${profile.xp.toLocaleString('fr-FR')} XP`;
     });
 
-    const heading = new SectionBuilder()
-        .addTextDisplayComponents(
-            new TextDisplayBuilder().setContent(
-                `-# KEPLER • CLASSEMENT XP\n## ${interaction.guild!.name}\n` +
-                'Les dix membres ayant accumulé le plus d’expérience.'
-            )
-        );
+    const headingContent = new TextDisplayBuilder().setContent(
+        `-# KEPLER • CLASSEMENT XP\n## ${interaction.guild!.name}\n` +
+        'Les dix membres ayant accumulé le plus d’expérience.'
+    );
     const iconUrl = interaction.guild!.iconURL({ forceStatic: true });
-    if (iconUrl) heading.setThumbnailAccessory(new ThumbnailBuilder().setURL(iconUrl));
-    const container = xpContainer('primary')
-        .addSectionComponents(heading)
+    const container = xpContainer('primary');
+    if (iconUrl) {
+        container.addSectionComponents(
+            new SectionBuilder()
+                .addTextDisplayComponents(headingContent)
+                .setThumbnailAccessory(new ThumbnailBuilder().setURL(iconUrl))
+        );
+    } else {
+        container.addTextDisplayComponents(headingContent);
+    }
+    container
         .addSeparatorComponents(new SeparatorBuilder().setDivider(true))
         .addTextDisplayComponents(
             new TextDisplayBuilder().setContent(rows.join('\n') || KEPLER_MESSAGES.noData)

--- a/commands/general/xp.ts
+++ b/commands/general/xp.ts
@@ -32,7 +32,18 @@ function xpContainer(tone: keyof typeof KEPLER_COLORS = 'primary') {
 }
 
 function requesterFooter(interaction: ChatInputCommandInteraction) {
-    return new TextDisplayBuilder().setContent(`-# Demandé par ${interaction.user.username}`);
+    const timestamp = Math.floor(Date.now() / 1000);
+    return new SectionBuilder()
+        .addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(
+                `-# Demandé par ${interaction.user.username} • <t:${timestamp}:R>`
+            )
+        )
+        .setThumbnailAccessory(
+            new ThumbnailBuilder()
+                .setURL(interaction.user.displayAvatarURL({ forceStatic: true }))
+                .setDescription(`Avatar de ${interaction.user.username}`)
+        );
 }
 
 export const data = new SlashCommandBuilder()
@@ -90,7 +101,7 @@ async function showProfile(interaction: ChatInputCommandInteraction) {
             xpContainer('neutral')
                 .addSectionComponents(section)
                 .addSeparatorComponents(new SeparatorBuilder().setDivider(false))
-                .addTextDisplayComponents(requesterFooter(interaction))
+                .addSectionComponents(requesterFooter(interaction))
         ));
         return;
     }
@@ -126,7 +137,7 @@ async function showProfile(interaction: ChatInputCommandInteraction) {
             )
         )
         .addSeparatorComponents(new SeparatorBuilder().setDivider(false))
-        .addTextDisplayComponents(
+        .addSectionComponents(
             requesterFooter(interaction)
         );
     await interaction.editReply(xpMessage(container));
@@ -156,7 +167,7 @@ async function showLeaderboard(interaction: ChatInputCommandInteraction) {
             new TextDisplayBuilder().setContent(rows.join('\n') || KEPLER_MESSAGES.noData)
         )
         .addSeparatorComponents(new SeparatorBuilder().setDivider(false))
-        .addTextDisplayComponents(
+        .addSectionComponents(
             requesterFooter(interaction)
         );
     await interaction.editReply(xpMessage(container));

--- a/commands/general/xp.ts
+++ b/commands/general/xp.ts
@@ -33,17 +33,9 @@ function xpContainer(tone: keyof typeof KEPLER_COLORS = 'primary') {
 
 function requesterFooter(interaction: ChatInputCommandInteraction) {
     const timestamp = Math.floor(Date.now() / 1000);
-    return new SectionBuilder()
-        .addTextDisplayComponents(
-            new TextDisplayBuilder().setContent(
-                `-# Demandé par ${interaction.user.username} • <t:${timestamp}:R>`
-            )
-        )
-        .setThumbnailAccessory(
-            new ThumbnailBuilder()
-                .setURL(interaction.user.displayAvatarURL({ forceStatic: true }))
-                .setDescription(`Avatar de ${interaction.user.username}`)
-        );
+    return new TextDisplayBuilder().setContent(
+        `-# Demandé par ${interaction.user.username} • <t:${timestamp}:R>`
+    );
 }
 
 export const data = new SlashCommandBuilder()
@@ -101,7 +93,7 @@ async function showProfile(interaction: ChatInputCommandInteraction) {
             xpContainer('neutral')
                 .addSectionComponents(section)
                 .addSeparatorComponents(new SeparatorBuilder().setDivider(false))
-                .addSectionComponents(requesterFooter(interaction))
+                .addTextDisplayComponents(requesterFooter(interaction))
         ));
         return;
     }
@@ -137,7 +129,7 @@ async function showProfile(interaction: ChatInputCommandInteraction) {
             )
         )
         .addSeparatorComponents(new SeparatorBuilder().setDivider(false))
-        .addSectionComponents(
+        .addTextDisplayComponents(
             requesterFooter(interaction)
         );
     await interaction.editReply(xpMessage(container));
@@ -167,7 +159,7 @@ async function showLeaderboard(interaction: ChatInputCommandInteraction) {
             new TextDisplayBuilder().setContent(rows.join('\n') || KEPLER_MESSAGES.noData)
         )
         .addSeparatorComponents(new SeparatorBuilder().setDivider(false))
-        .addSectionComponents(
+        .addTextDisplayComponents(
             requesterFooter(interaction)
         );
     await interaction.editReply(xpMessage(container));

--- a/database/migrations/20260804_extend_automod_v1_1.sql
+++ b/database/migrations/20260804_extend_automod_v1_1.sql
@@ -1,0 +1,30 @@
+-- AutoMod V1.1: observation, filtres personnalisés et sanctions par règle.
+alter table public.guild_automod_settings
+    add column if not exists observation_mode boolean not null default false,
+    add column if not exists anti_keyword_enabled boolean not null default false,
+    add column if not exists blocked_keywords text[] not null default '{}',
+    add column if not exists allowed_keywords text[] not null default '{}',
+    add column if not exists regex_patterns text[] not null default '{}',
+    add column if not exists rule_actions jsonb not null default '{}'::jsonb,
+    add column if not exists escalation_steps jsonb not null default '[]'::jsonb;
+
+alter table public.guild_automod_settings
+    add column if not exists anti_raid_enabled boolean not null default false,
+    add column if not exists raid_join_count integer not null default 8 check (raid_join_count between 3 and 50),
+    add column if not exists raid_interval_seconds integer not null default 20 check (raid_interval_seconds between 5 and 300),
+    add column if not exists raid_account_age_hours integer not null default 24 check (raid_account_age_hours between 1 and 720),
+    add column if not exists raid_mode_seconds integer not null default 600 check (raid_mode_seconds between 60 and 3600);
+
+alter table public.guild_automod_violations
+    add column if not exists source text not null default 'message_create',
+    add column if not exists observed boolean not null default false;
+
+alter table public.guild_automod_violations
+    drop constraint if exists guild_automod_violations_rule_check;
+
+alter table public.guild_automod_violations
+    add constraint guild_automod_violations_rule_check
+    check (rule in ('link', 'invite', 'spam', 'duplicate', 'caps', 'mentions', 'keyword'));
+
+create index if not exists guild_automod_violations_stats_idx
+    on public.guild_automod_violations (guild_id, rule, created_at desc);

--- a/database/migrations/20260805_add_member_flow_stats.sql
+++ b/database/migrations/20260805_add_member_flow_stats.sql
@@ -1,0 +1,30 @@
+-- Agrégation quotidienne des arrivées et départs pour les graphiques serveur.
+create or replace function public.get_guild_member_flow(
+    p_guild_id text,
+    p_since timestamptz default null
+)
+returns table (stat_date date, joins bigint, leaves bigint)
+language sql
+security definer
+set search_path = public
+as $$
+    with events as (
+        select joined_at::date as event_date, 1::bigint as joins, 0::bigint as leaves
+        from public.guild_invite_joins
+        where guild_id = p_guild_id
+          and (p_since is null or joined_at >= p_since)
+        union all
+        select left_at::date as event_date, 0::bigint as joins, 1::bigint as leaves
+        from public.guild_invite_joins
+        where guild_id = p_guild_id
+          and left_at is not null
+          and (p_since is null or left_at >= p_since)
+    )
+    select event_date, sum(events.joins)::bigint, sum(events.leaves)::bigint
+    from events
+    group by event_date
+    order by event_date;
+$$;
+
+revoke execute on function public.get_guild_member_flow(text, timestamptz) from public, anon, authenticated;
+grant execute on function public.get_guild_member_flow(text, timestamptz) to service_role;

--- a/database/migrations/20260806_set_default_xp_cooldown.sql
+++ b/database/migrations/20260806_set_default_xp_cooldown.sql
@@ -1,0 +1,4 @@
+-- Les nouvelles configurations XP utilisent un cooldown plus dynamique.
+-- Les lignes existantes conservent volontairement leur valeur actuelle.
+alter table public.guild_xp_settings
+    alter column cooldown_seconds set default 5;

--- a/database/migrations/README.md
+++ b/database/migrations/README.md
@@ -13,6 +13,7 @@ chronologique du nom de fichier.
 5. `20260728_add_xp_logs.sql`
 6. `20260728_add_invite_manager.sql`
 7. `20260728_add_automod_system.sql`
+8. `20260804_extend_automod_v1_1.sql`
 8. `20260729_track_ticket_panel_message.sql`
 
 La migration XP principale contient déjà la structure finale, la RLS et la

--- a/database/migrations/README.md
+++ b/database/migrations/README.md
@@ -14,6 +14,7 @@ chronologique du nom de fichier.
 6. `20260728_add_invite_manager.sql`
 7. `20260728_add_automod_system.sql`
 8. `20260804_extend_automod_v1_1.sql`
+9. `20260805_add_member_flow_stats.sql`
 8. `20260729_track_ticket_panel_message.sql`
 
 La migration XP principale contient déjà la structure finale, la RLS et la

--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,7 @@
         "start": "deno run --allow-net --allow-read --allow-env index.ts"
     },
     "imports": {
-        "discord.js": "npm:discord.js@^14.17.2"
+        "discord.js": "npm:discord.js@14.23.2"
     },
     "compilerOptions": {
         "strict": true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   deno:
     build: .
-    container_name: kepler-bot-dev
+    container_name: kepler-bot-prod
     restart: always
     environment:
       TOKEN: ${TOKEN}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   deno:
     build: .
-    container_name: kepler-bot-prod
+    container_name: kepler-bot-dev
     restart: always
     environment:
       TOKEN: ${TOKEN}

--- a/docs/AUTOMOD.md
+++ b/docs/AUTOMOD.md
@@ -53,6 +53,14 @@ Le panneau affiche le volume des détections des sept derniers jours. Les
 déclenchements des règles AutoMod natives de Discord sont également intégrés à
 l’historique Kepler lorsque les intents correspondants sont disponibles.
 
+## Navigation dans `/settings`
+
+La rubrique **Modération** centralise désormais l’AutoMod, les sanctions et le
+rôle de mute, les signalements ainsi que le journal de modération. L’AutoMod
+est lui-même divisé en cinq écrans : **Général**, **Protections**, **Filtres et
+seuils**, **Sanctions** et **Exemptions**. Chaque sauvegarde ramène dans son
+écran d’origine afin d’éviter de recommencer la navigation.
+
 Chaque détection est conservée dans `guild_automod_violations` et envoyée dans
 le salon de modération configuré. Si le bot ne peut pas appliquer un timeout,
 le message reste supprimé et l’échec n’empêche pas le traitement des messages

--- a/docs/AUTOMOD.md
+++ b/docs/AUTOMOD.md
@@ -26,6 +26,12 @@ salon de modération, y envoyer des messages et intégrer des liens.
 - **Majuscules** : pourcentage configurable, appliqué uniquement après un
   nombre minimal de lettres.
 - **Mentions massives** : utilisateurs, rôles, `@everyone` et `@here`.
+- **Mots et expressions** : termes personnalisés, exceptions et expressions
+  régulières, avec normalisation des accents et caractères invisibles.
+- **Messages modifiés** : une édition repasse dans les filtres de contenu sans
+  être comptée comme un nouveau message dans les seuils de spam.
+- **Anti-raid** : une rafale d’arrivées active temporairement une protection
+  renforcée des comptes très récents.
 
 Les administrateurs et les membres possédant **Gérer les messages** sont
 toujours exemptés. Des rôles, salons et catégories supplémentaires peuvent
@@ -38,6 +44,15 @@ toujours exemptés. Des rôles, salons et catégories supplémentaires peuvent
 - `timeout` : suppression puis timeout après un nombre configurable
   d’infractions dans une fenêtre glissante.
 
+Les actions peuvent être définies par règle. Une progression peut ensuite les
+remplacer selon le nombre d’infractions, par exemple
+`1=delete,2=warn,3=timeout:600`. Le **mode observation** enregistre et journalise
+les détections sans supprimer le message ni sanctionner le membre.
+
+Le panneau affiche le volume des détections des sept derniers jours. Les
+déclenchements des règles AutoMod natives de Discord sont également intégrés à
+l’historique Kepler lorsque les intents correspondants sont disponibles.
+
 Chaque détection est conservée dans `guild_automod_violations` et envoyée dans
 le salon de modération configuré. Si le bot ne peut pas appliquer un timeout,
 le message reste supprimé et l’échec n’empêche pas le traitement des messages
@@ -48,3 +63,9 @@ embed en message privé. Aucun avertissement public n’est envoyé dans le salo
 si les messages privés sont fermés, seule l’équipe voit le log de modération.
 Les MP sont limités à un toutes les 15 secondes par utilisateur afin qu’une
 rafale ne soit pas remplacée par une rafale de notifications du bot.
+
+## Mise à niveau V1.1
+
+Après la migration initiale, exécuter
+`database/migrations/20260804_extend_automod_v1_1.sql` dans Supabase. La
+migration est additive et conserve les réglages existants.

--- a/docs/AUTOMOD.md
+++ b/docs/AUTOMOD.md
@@ -61,6 +61,17 @@ est lui-même divisé en cinq écrans : **Général**, **Protections**, **Filtre
 seuils**, **Sanctions** et **Exemptions**. Chaque sauvegarde ramène dans son
 écran d’origine afin d’éviter de recommencer la navigation.
 
+Les autres modules suivent la même convention :
+
+- **Invitations** : Général, Salons, Événements journalisés et Annonce
+  d’arrivée ;
+- **Tickets** : résumé, Emplacements et accès, Apparence du panneau et
+  Publication ;
+- **Expérience** : Général, Boosts, Récompenses, Exclusions et Journal.
+
+Les écrans simples, comme les logs serveur, les anniversaires et le fuseau
+horaire, restent accessibles directement depuis l’accueil.
+
 Chaque détection est conservée dans `guild_automod_violations` et envoyée dans
 le salon de modération configuré. Si le bot ne peut pas appliquer un timeout,
 le message reste supprimé et l’échec n’empêche pas le traitement des messages

--- a/docs/DIRECTION-ARTISTIQUE.md
+++ b/docs/DIRECTION-ARTISTIQUE.md
@@ -49,6 +49,12 @@ couleur produite par un utilisateur, un rôle Discord ou un contenu externe.
 ## Graphiques
 
 - Format 16:9, fond graphite, panneau sombre et filet bleu orbital.
+- Les séries simultanées doivent combiner couleurs contrastées et styles de
+  trait distincts ; la seconde série est affichée en pointillés.
+- Les axes affichent au maximum sept libellés régulièrement espacés afin
+  d’éviter tout chevauchement.
+- Les libellés sont tronqués par graphème et utilisent Noto Color Emoji dans
+  l’image Docker pour ne pas couper les séquences emoji.
 - Blanc lunaire pour les valeurs, argent pour les axes et légendes.
 - Séries fixes : messages en bleu orbital, commandes en bleu signal.
 - Les autres classements utilisent les tokens de `KEPLER_CHART_COLORS`.

--- a/docs/GRAPH_COMMAND.md
+++ b/docs/GRAPH_COMMAND.md
@@ -1,156 +1,34 @@
-# Commande Graph - Statistiques du Serveur
+# Statistiques serveur
 
-## Vue d'ensemble
+La commande `/graph` ouvre un panneau public réservé aux administrateurs. Le
+message et ses graphiques sont visibles par tout le serveur ; seul
+l’administrateur ayant lancé la commande peut utiliser ses composants.
 
-La commande `/graph` a été complètement repensée pour offrir des statistiques détaillées spécifiques à chaque serveur Discord. Les administrateurs de serveur peuvent désormais analyser l'activité et les tendances de leur communauté.
+## Vues disponibles
 
-## Permissions
+- **Résumé de l’activité** : messages, commandes, membres actuels et commandes
+  les plus utilisées ;
+- **Messages et commandes** : évolution quotidienne des deux volumes ;
+- **Arrivées et départs** : deux courbes quotidiennes et solde net de membres ;
+- **État actuel** : humains, bots, membres en ligne, rôles et boosts ;
+- **Salons actifs** : salons classés par nombre de messages ;
+- **Membres actifs** : membres classés par nombre de messages ;
+- **Commandes utilisées** : commandes classées par nombre d’exécutions.
 
-- **`/graph`** : Requiert les permissions d'**Administrateur** sur le serveur
-- **`/globalstats`** : Réservé au **propriétaire du bot** uniquement (statistiques globales multi-serveurs)
+Les vues historiques acceptent les périodes de 7, 30, 90, 180 ou 360 jours,
+ainsi que toute la période conservée en base.
 
-## Sous-commandes disponibles
+## Arrivées et départs
 
-### `/graph vue-ensemble`
-Affiche une vue d'ensemble complète des statistiques du serveur :
-- 👥 **Membres** : Total, humains, bots
-- 📨 **Activité** : Messages et commandes sur la période choisie
-- 📈 **Historique** : Statistiques totales depuis le début du tracking
-- 📉 **Tendances** : Graphiques de tendance sur 14 jours
-- 🏆 **Top 5** : Commandes les plus utilisées
+Cette vue dépend de `guild_invite_joins`. Elle comptabilise toutes les arrivées
+suivies par le manager d’invitations et les départs associés. Les données
+antérieures à l’installation de ce suivi ne peuvent pas être reconstruites.
 
-**Options :**
-- `jours` : Nombre de jours à analyser (7-90, défaut: 30)
+Exécuter `database/migrations/20260805_add_member_flow_stats.sql` pour installer
+la fonction d’agrégation quotidienne utilisée par le graphique.
 
-### `/graph activite`
-Statistiques détaillées sur l'activité du serveur :
-- 💬 **Messages** : Total, moyenne quotidienne, jour record
-- ⚡ **Commandes** : Total, moyenne quotidienne
-- 📊 **Graphique** : Tendance visuelle de l'activité
+## Données et confidentialité
 
-**Options :**
-- `jours` : Nombre de jours à analyser (7-90, défaut: 30)
-
-### `/graph membres`
-Informations sur les membres du serveur :
-- 📊 **Composition** : Total membres, humains, bots, en ligne
-- 🎭 **Rôles** : Nombre de rôles, rôle le plus haut
-- 💎 **Boosts** : Niveau de boost et nombre de boosts
-- 📅 **Informations** : Date de création, propriétaire, canaux
-
-### `/graph canaux`
-Classement des canaux les plus actifs :
-- 📺 Liste des canaux avec graphique à barres
-- Nombre de messages par canal
-
-**Options :**
-- `jours` : Nombre de jours à analyser (7-90, défaut: 30)
-- `limite` : Nombre de canaux à afficher (5-15, défaut: 10)
-
-### `/graph utilisateurs`
-Classement des utilisateurs les plus actifs :
-- 👑 Top des membres avec médailles (🥇🥈🥉)
-- Nombre de messages par utilisateur
-
-**Options :**
-- `jours` : Nombre de jours à analyser (7-90, défaut: 30)
-- `limite` : Nombre d'utilisateurs à afficher (5-20, défaut: 10)
-
-### `/graph commandes`
-Statistiques sur l'utilisation des commandes :
-- ⚡ Total et moyenne des commandes
-- 🏆 Top 10 des commandes utilisées avec graphique
-- 📉 Tendance sur 14 jours
-
-**Options :**
-- `jours` : Nombre de jours à analyser (7-90, défaut: 30)
-
-## Commande GlobalStats (Owner uniquement)
-
-### `/globalstats vue-ensemble`
-Vue d'ensemble des statistiques globales du bot (tous les serveurs confondus)
-
-### `/globalstats commandes`
-Statistiques globales des commandes exécutées
-
-**Options :**
-- `jours` : Nombre de jours à analyser (1-90, défaut: 30)
-
-### `/globalstats messages`
-Statistiques globales des messages
-
-**Options :**
-- `jours` : Nombre de jours à analyser (1-90, défaut: 30)
-
-### `/globalstats tendance`
-Graphique de tendance global
-
-**Options :**
-- `type` : Type de statistique (commandes/messages) - **Requis**
-- `jours` : Nombre de jours (7-30, défaut: 14)
-
-## Éléments visuels
-
-Les graphiques utilisent des caractères ASCII pour une visualisation claire :
-- **Barres horizontales** : `█░` pour les classements
-- **Sparklines** : `▁▂▃▄▅▆▇█` pour les tendances rapides
-- **Graphiques verticaux** : Pour les tendances détaillées
-
-## Nouvelles fonctionnalités ajoutées
-
-1. **Statistiques des canaux** : Identification des canaux les plus actifs
-2. **Statistiques des membres** : Informations détaillées sur la composition du serveur
-3. **Graphiques visuels améliorés** : Meilleure lisibilité
-4. **Séparation Owner/Admin** : 
-   - `/graph` pour les administrateurs de serveur
-   - `/globalstats` pour le propriétaire du bot
-5. **Personnalisation** : Options de période et de limite configurable
-
-## Modifications techniques
-
-### Fichiers modifiés :
-- **`commands/administration/graph.ts`** : Nouvelle implémentation pour les serveurs
-- **`utils/stats/tracker.ts`** : Ajout de la fonction `getTopChannels()`
-
-### Nouveaux fichiers :
-- **`commands/administration/globalstats.ts`** : Commande pour les statistiques globales (owner)
-
-### Fonctions ajoutées dans statsTracker :
-```typescript
-getTopChannels(days: number, limit: number, guildId: string): Promise<ChannelActivity[]>
-```
-
-## Exemples d'utilisation
-
-```
-/graph vue-ensemble jours:30
-→ Affiche une vue d'ensemble des 30 derniers jours
-
-/graph canaux jours:7 limite:5
-→ Affiche les 5 canaux les plus actifs sur 7 jours
-
-/graph utilisateurs jours:14 limite:15
-→ Affiche les 15 utilisateurs les plus actifs sur 14 jours
-
-/globalstats tendance type:messages jours:30
-→ (Owner) Graphique de tendance des messages sur 30 jours
-```
-
-## Migration depuis l'ancienne version
-
-L'ancienne commande `/graph` réservée à l'owner a été renommée `/globalstats`. Les fonctionnalités sont préservées mais maintenant séparées :
-
-**Avant :**
-- `/graph` avec option `global:true/false`
-
-**Maintenant :**
-- `/graph` : Pour les administrateurs (stats du serveur uniquement)
-- `/globalstats` : Pour l'owner (stats globales)
-
-## Base de données
-
-Les statistiques sont trackées automatiquement dans les tables :
-- `daily_stats` : Statistiques journalières par serveur
-- `command_stats` : Historique des commandes exécutées
-- `message_stats` : Statistiques de messages par canal/utilisateur
-- `global_daily_stats` : Statistiques globales (tous serveurs)
+Les graphiques présentent des agrégats du serveur. Ils ne contiennent pas le
+contenu des messages. Les classements affichent uniquement les noms visibles
+sur le serveur et les volumes de messages associés.

--- a/events/handlers/autoModerationActionExecution.ts
+++ b/events/handlers/autoModerationActionExecution.ts
@@ -1,0 +1,39 @@
+import { Events } from 'discord.js';
+import { recordAutoModViolation, type AutoModRule } from '../../utils/moderation/automodService.ts';
+import { logger } from '../../utils/logger.ts';
+
+export const name = Events.AutoModerationActionExecution;
+export const once = false;
+
+export async function execute(event: {
+    guildId: string;
+    userId: string;
+    channelId?: string;
+    messageId?: string;
+    ruleTriggerType: number;
+    content?: string;
+}) {
+    const ruleByTrigger: Record<number, AutoModRule> = {
+        1: 'keyword',
+        3: 'spam',
+        4: 'keyword',
+        5: 'mentions',
+        6: 'keyword'
+    };
+    const rule = ruleByTrigger[event.ruleTriggerType] ?? 'keyword';
+    try {
+        await recordAutoModViolation(
+            event.guildId,
+            event.userId,
+            event.channelId ?? event.guildId,
+            event.messageId ?? `native-${Date.now()}`,
+            rule,
+            'native',
+            event.content ?? '',
+            'native',
+            false
+        );
+    } catch (error) {
+        logger.error('Erreur journalisation AutoMod natif', error, 'AUTOMOD');
+    }
+}

--- a/events/handlers/guildMemberAdd.ts
+++ b/events/handlers/guildMemberAdd.ts
@@ -9,6 +9,11 @@ export const once = false;
 
 export async function execute(member: GuildMember) {
     try {
+        await member.client.moderationManager?.handleMemberJoin(member);
+    } catch (error) {
+        logger.error(`Erreur anti-raid pour ${member.id}`, error, 'AUTOMOD');
+    }
+    try {
         await member.client.inviteManager?.handleMemberJoin(member);
     } catch (error) {
         logger.error(`Erreur détection invitation de ${member.id}`, error, 'INVITES');

--- a/events/handlers/messageUpdate.ts
+++ b/events/handlers/messageUpdate.ts
@@ -1,9 +1,20 @@
 import { Events, Message, PartialMessage } from 'discord.js';
 import { logMessageUpdate } from '../logs/messageLogs.ts';
+import { logger } from '../../utils/logger.ts';
 
 export const name = Events.MessageUpdate;
 export const once = false;
 
 export async function execute(oldMessage: Message | PartialMessage, newMessage: Message | PartialMessage) {
     await logMessageUpdate(oldMessage, newMessage);
+    if (!newMessage.guild || newMessage.author?.bot) return;
+    try {
+        const message = newMessage.partial ? await newMessage.fetch() : newMessage;
+        const client = message.client as typeof message.client & {
+            moderationManager?: { handleMessage(message: Message, source: 'message_update'): Promise<boolean> };
+        };
+        await client.moderationManager?.handleMessage(message, 'message_update');
+    } catch (error) {
+        logger.error('Erreur auto-modération après modification', error, 'AUTOMOD');
+    }
 }

--- a/index.ts
+++ b/index.ts
@@ -19,7 +19,9 @@ const client = new Client({
         GatewayIntentBits.GuildVoiceStates,
         GatewayIntentBits.GuildBans,
         GatewayIntentBits.GuildInvites,
-        GatewayIntentBits.GuildEmojisAndStickers
+        GatewayIntentBits.GuildEmojisAndStickers,
+        GatewayIntentBits.AutoModerationConfiguration,
+        GatewayIntentBits.AutoModerationExecution
     ] 
 });
 
@@ -84,6 +86,7 @@ async function loadEvents() {
         'events/handlers/messageDelete.ts',
         'events/handlers/messageDeleteBulk.ts',
         'events/handlers/messageUpdate.ts',
+        'events/handlers/autoModerationActionExecution.ts',
         'events/handlers/roleCreate.ts',
         'events/handlers/roleDelete.ts',
         'events/handlers/roleUpdate.ts',

--- a/managers/moderationManager.ts
+++ b/managers/moderationManager.ts
@@ -1,14 +1,15 @@
-import { Client, type Message } from 'discord.js';
+import { Client, type GuildMember, type Message } from 'discord.js';
 import { getExpiredTempBans, getExpiredTempMutes, removeTempBan, removeTempMute } from '../database/db.ts';
 import { logModeration } from '../utils/moderation/logger.ts';
 import { isNetworkError, isMaintenanceError, dbCircuitBreaker } from '../utils/retryHelper.ts';
 import { logger } from '../utils/logger.ts';
 import { AutoModeration } from '../utils/moderation/automod.ts';
 import { getAutoModSettings } from '../utils/moderation/automodService.ts';
+import type { AutoModSource } from '../utils/moderation/automodService.ts';
 
 export class ModerationManager {
     private client: Client;
-    private checkInterval: NodeJS.Timeout | null = null;
+    private checkInterval: ReturnType<typeof setInterval> | null = null;
     private lastMaintenanceLog: number = 0;
     private readonly autoModeration: AutoModeration;
 
@@ -17,8 +18,12 @@ export class ModerationManager {
         this.autoModeration = new AutoModeration(client);
     }
 
-    async handleMessage(message: Message): Promise<boolean> {
-        return this.autoModeration.handleMessage(message);
+    async handleMessage(message: Message, source: AutoModSource = 'message_create'): Promise<boolean> {
+        return this.autoModeration.handleMessage(message, source);
+    }
+
+    async handleMemberJoin(member: GuildMember): Promise<void> {
+        await this.autoModeration.handleMemberJoin(member);
     }
 
     async start(): Promise<void> {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "axios": "^1.7.9",
     "dayjs": "^1.11.13",
-    "discord.js": "14.14.1",
+    "discord.js": "14.23.2",
     "dotenv": "^16.4.7",
     "qrcode": "^1.5.3",
     "sharp": "^0.33.1",

--- a/utils/invites/service.ts
+++ b/utils/invites/service.ts
@@ -209,3 +209,31 @@ export async function getInviteMemberStats(
         active_members: Number(row?.active_members ?? 0)
     };
 }
+
+export interface DailyMemberFlow {
+    date: string;
+    joins: number;
+    leaves: number;
+}
+
+export async function getMemberFlowStats(guildId: string, days: number | null = 30): Promise<DailyMemberFlow[]> {
+    const since = days === null ? null : new Date(Date.now() - days * 86_400_000).toISOString();
+    const { data, error } = await supabase.rpc('get_guild_member_flow', {
+        p_guild_id: guildId,
+        p_since: since
+    });
+    if (error) throw new Error(`Évolution des membres impossible : ${error.message}`);
+
+    const values = new Map<string, DailyMemberFlow>((data ?? []).map((row: any) => [
+        String(row.stat_date),
+        { date: String(row.stat_date), joins: Number(row.joins ?? 0), leaves: Number(row.leaves ?? 0) }
+    ]));
+    if (days === null) return [...values.values()];
+
+    const result: DailyMemberFlow[] = [];
+    for (let offset = days - 1; offset >= 0; offset--) {
+        const date = new Date(Date.now() - offset * 86_400_000).toISOString().slice(0, 10);
+        result.push(values.get(date) ?? { date, joins: 0, leaves: 0 });
+    }
+    return result;
+}

--- a/utils/leaderboardPagination.ts
+++ b/utils/leaderboardPagination.ts
@@ -1,0 +1,113 @@
+import {
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+    type ChatInputCommandInteraction,
+    type InteractionEditReplyOptions,
+    type Message,
+    ModalBuilder,
+    TextInputBuilder,
+    TextInputStyle
+} from 'discord.js';
+import { KEPLER_MESSAGES } from './theme.ts';
+
+export const LEADERBOARD_PAGE_SIZE = 10;
+const PAGINATION_TIMEOUT = 5 * 60 * 1000;
+
+export function leaderboardControls(prefix: string, page: number, totalPages: number, disabled = false) {
+    return new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+            .setCustomId(`${prefix}:previous`)
+            .setEmoji('◀️')
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(disabled || page === 0),
+        new ButtonBuilder()
+            .setCustomId(`${prefix}:jump`)
+            .setLabel(`Page ${page + 1}/${totalPages}`)
+            .setEmoji('🔢')
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(disabled || totalPages <= 1),
+        new ButtonBuilder()
+            .setCustomId(`${prefix}:next`)
+            .setEmoji('▶️')
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(disabled || page >= totalPages - 1)
+    );
+}
+
+export function attachLeaderboardPagination(
+    interaction: ChatInputCommandInteraction,
+    message: Message,
+    prefix: string,
+    totalPages: number,
+    render: (page: number, disabled?: boolean) => InteractionEditReplyOptions
+) {
+    if (totalPages <= 1) return;
+    let currentPage = 0;
+    const collector = message.createMessageComponentCollector({
+        time: PAGINATION_TIMEOUT,
+        filter: component => component.customId.startsWith(`${prefix}:`)
+    });
+
+    collector.on('collect', async component => {
+        if (!component.isButton()) return;
+        if (component.user.id !== interaction.user.id) {
+            await component.reply({ content: KEPLER_MESSAGES.unauthorizedComponent, ephemeral: true });
+            return;
+        }
+
+        if (component.customId === `${prefix}:previous`) {
+            currentPage = Math.max(0, currentPage - 1);
+            await component.update(render(currentPage));
+            return;
+        }
+        if (component.customId === `${prefix}:next`) {
+            currentPage = Math.min(totalPages - 1, currentPage + 1);
+            await component.update(render(currentPage));
+            return;
+        }
+
+        const modal = new ModalBuilder()
+            .setCustomId(`${prefix}:jump-modal`)
+            .setTitle('Aller à une page')
+            .addComponents(
+                new ActionRowBuilder<TextInputBuilder>().addComponents(
+                    new TextInputBuilder()
+                        .setCustomId('page')
+                        .setLabel(`Numéro de page (1 à ${totalPages})`)
+                        .setStyle(TextInputStyle.Short)
+                        .setRequired(true)
+                        .setMinLength(1)
+                        .setMaxLength(String(totalPages).length)
+                )
+            );
+        await component.showModal(modal);
+        const submission = await component.awaitModalSubmit({
+            time: 60_000,
+            filter: modalInteraction =>
+                modalInteraction.user.id === interaction.user.id &&
+                modalInteraction.customId === `${prefix}:jump-modal`
+        }).catch(() => null);
+        if (!submission) return;
+
+        const requestedPage = Number(submission.fields.getTextInputValue('page'));
+        if (!Number.isInteger(requestedPage) || requestedPage < 1 || requestedPage > totalPages) {
+            await submission.reply({
+                content: `❌ Entrez un numéro de page entre 1 et ${totalPages}.`,
+                ephemeral: true
+            });
+            return;
+        }
+        currentPage = requestedPage - 1;
+        await submission.deferUpdate();
+        await submission.editReply(render(currentPage));
+    });
+
+    collector.on('end', async () => {
+        try {
+            await interaction.editReply(render(currentPage, true));
+        } catch {
+            // Le message peut avoir été supprimé entre-temps.
+        }
+    });
+}

--- a/utils/moderation/automod.ts
+++ b/utils/moderation/automod.ts
@@ -12,7 +12,9 @@ import {
     getAutoModSettings,
     getAutoModStrikeCount,
     recordAutoModViolation,
+    type AutoModAction,
     type AutoModRule,
+    type AutoModSource,
     type AutoModSettings
 } from './automodService.ts';
 
@@ -27,7 +29,8 @@ const RULE_LABELS: Record<AutoModRule, string> = {
     spam: 'rafale de messages',
     duplicate: 'messages répétés',
     caps: 'usage excessif des majuscules',
-    mentions: 'mentions massives'
+    mentions: 'mentions massives',
+    keyword: 'contenu interdit'
 };
 
 const INVITE_PATTERN = /(?:https?:\/\/)?(?:www\.)?(?:discord\.gg|discord(?:app)?\.com\/invite)\/([a-z0-9-]+)/gi;
@@ -39,14 +42,45 @@ export class AutoModeration {
     private readonly enforcementQueues = new Map<string, Promise<void>>();
     private readonly cleanupTimers = new Map<string, ReturnType<typeof setTimeout>>();
     private readonly lastNotificationAt = new Map<string, number>();
+    private readonly recentJoins = new Map<string, number[]>();
+    private readonly raidModeUntil = new Map<string, number>();
 
     constructor(private readonly client: Client) {}
 
-    async handleMessage(message: Message): Promise<boolean> {
+    async handleMemberJoin(member: GuildMember): Promise<void> {
+        const settings = await getAutoModSettings(member.guild.id);
+        if (!settings.enabled || !settings.anti_raid_enabled || member.user.bot) return;
+        const now = Date.now();
+        const windowStart = now - settings.raid_interval_seconds * 1000;
+        const joins = (this.recentJoins.get(member.guild.id) ?? []).filter(at => at >= windowStart);
+        joins.push(now);
+        this.recentJoins.set(member.guild.id, joins);
+        const wasActive = (this.raidModeUntil.get(member.guild.id) ?? 0) > now;
+        if (joins.length >= settings.raid_join_count) {
+            this.raidModeUntil.set(member.guild.id, now + settings.raid_mode_seconds * 1000);
+            if (!wasActive) await logModeration(
+                member.guild,
+                'AutoMod',
+                member.user,
+                this.client.user!,
+                `Mode anti-raid activé : ${joins.length} arrivées en ${settings.raid_interval_seconds}s`,
+                `${settings.raid_mode_seconds}s`
+            );
+        }
+        if ((this.raidModeUntil.get(member.guild.id) ?? 0) <= now) return;
+        const accountAgeHours = (now - member.user.createdTimestamp) / 3_600_000;
+        if (accountAgeHours >= settings.raid_account_age_hours || !member.moderatable) return;
+        await member.timeout(
+            Math.min(settings.timeout_seconds * 1000, 28 * 86_400_000),
+            `AutoMod anti-raid : compte créé il y a ${Math.floor(accountAgeHours)}h`
+        ).catch(error => logger.warn(`Timeout anti-raid impossible pour ${member.id}`, error, 'AUTOMOD'));
+    }
+
+    async handleMessage(message: Message, source: AutoModSource = 'message_create'): Promise<boolean> {
         if (!message.guild) return false;
         const key = `${message.guild.id}:${message.author.id}`;
         const previous = this.queues.get(key) ?? Promise.resolve(false);
-        const next = previous.catch(() => false).then(() => this.processMessage(message));
+        const next = previous.catch(() => false).then(() => this.processMessage(message, source));
         this.queues.set(key, next);
         try {
             return await next;
@@ -55,35 +89,38 @@ export class AutoModeration {
         }
     }
 
-    private async processMessage(message: Message): Promise<boolean> {
+    private async processMessage(message: Message, source: AutoModSource): Promise<boolean> {
         if (!message.guild || !message.member || message.author.bot) return false;
         const settings = await getAutoModSettings(message.guild.id);
         if (!settings.enabled || this.isExempt(message, settings)) return false;
 
-        const rule = await this.detectViolation(message, settings);
+        const rule = await this.detectViolation(message, settings, source === 'message_create');
         if (!rule) return false;
 
-        await message.delete().catch(() => undefined);
-        void this.enqueueEnforcement(message, rule, settings);
-        return true;
+        if (!settings.observation_mode) await message.delete().catch(() => undefined);
+        void this.enqueueEnforcement(message, rule, settings, source);
+        return !settings.observation_mode;
     }
 
     private async enforceViolation(
         message: Message,
         rule: AutoModRule,
-        settings: AutoModSettings
+        settings: AutoModSettings,
+        source: AutoModSource
     ): Promise<void> {
         const member = message.member;
         if (!message.guild || !member) return;
         const strikes = await getAutoModStrikeCount(message.guild.id, message.author.id) + 1;
-        let action = await this.applyAction(member, rule, settings);
-        if (settings.action === 'timeout' && strikes >= settings.strike_threshold) {
-            action = await this.timeoutMember(member, rule, settings, strikes).catch(error => {
+        const selectedAction = this.resolveAction(rule, settings, strikes);
+        let action = settings.observation_mode ? 'observed' : await this.applyAction(member, rule, selectedAction);
+        if (!settings.observation_mode && selectedAction === 'timeout') {
+            const timeoutSeconds = this.resolveTimeoutSeconds(settings, strikes);
+            action = await this.timeoutMember(member, rule, timeoutSeconds, strikes).catch(error => {
                 logger.warn(`Timeout AutoMod impossible pour ${message.author.id}`, error, 'AUTOMOD');
                 return 'delete';
             });
         }
-        void this.notifyUser(message, rule, action, settings);
+        if (!settings.observation_mode) void this.notifyUser(message, rule, action, settings);
         await recordAutoModViolation(
             message.guild.id,
             message.author.id,
@@ -91,7 +128,9 @@ export class AutoModeration {
             message.id,
             rule,
             action,
-            message.content
+            message.content,
+            source,
+            settings.observation_mode
         );
 
         void this.sendLog(message, rule, action, strikes).catch(error => {
@@ -102,13 +141,14 @@ export class AutoModeration {
     private async enqueueEnforcement(
         message: Message,
         rule: AutoModRule,
-        settings: AutoModSettings
+        settings: AutoModSettings,
+        source: AutoModSource
     ): Promise<void> {
         const key = `${message.guildId}:${message.author.id}`;
         const previous = this.enforcementQueues.get(key) ?? Promise.resolve();
         const next = previous
             .catch(() => undefined)
-            .then(() => this.enforceViolation(message, rule, settings));
+            .then(() => this.enforceViolation(message, rule, settings, source));
         this.enforcementQueues.set(key, next);
         try {
             await next;
@@ -133,8 +173,9 @@ export class AutoModeration {
         return member.roles.cache.some(role => settings.excluded_role_ids.includes(role.id));
     }
 
-    private async detectViolation(message: Message, settings: AutoModSettings): Promise<AutoModRule | null> {
+    private async detectViolation(message: Message, settings: AutoModSettings, trackActivity: boolean): Promise<AutoModRule | null> {
         const content = message.content;
+        if (settings.anti_keyword_enabled && this.hasBlockedKeyword(content, settings)) return 'keyword';
         let contentForLinks = content;
         if (settings.anti_invite_enabled) {
             const matches = [...content.matchAll(INVITE_PATTERN)];
@@ -149,13 +190,13 @@ export class AutoModeration {
             (message.mentions.everyone ? settings.mention_limit : 0);
         if (settings.anti_mention_enabled && mentionCount >= settings.mention_limit) return 'mentions';
 
-        const recent = this.trackMessage(message, settings);
+        const recent = trackActivity ? this.trackMessage(message, settings) : [];
         const now = Date.now();
-        if (settings.anti_spam_enabled) {
+        if (trackActivity && settings.anti_spam_enabled) {
             const start = now - settings.spam_interval_seconds * 1000;
             if (recent.filter(entry => entry.at >= start).length >= settings.spam_message_count) return 'spam';
         }
-        if (settings.anti_duplicate_enabled) {
+        if (trackActivity && settings.anti_duplicate_enabled) {
             const normalized = this.normalize(message.content);
             if (normalized.length >= 3) {
                 const start = now - settings.duplicate_interval_seconds * 1000;
@@ -189,6 +230,29 @@ export class AutoModeration {
             .replace(/\s+/g, ' ')
             .replace(/[^\p{L}\p{N}\s]/gu, '')
             .trim();
+    }
+
+    private normalizeForKeyword(content: string): string {
+        return content.toLocaleLowerCase()
+            .normalize('NFKD')
+            .replace(/\p{M}/gu, '')
+            .replace(/[\u200B-\u200D\uFEFF]/g, '')
+            .replace(/[_.*~|`-]+/g, '')
+            .replace(/\s+/g, ' ')
+            .trim();
+    }
+
+    private hasBlockedKeyword(content: string, settings: AutoModSettings): boolean {
+        const normalized = this.normalizeForKeyword(content);
+        if (settings.allowed_keywords.some(value => normalized.includes(this.normalizeForKeyword(value)))) return false;
+        if (settings.blocked_keywords.some(value => normalized.includes(this.normalizeForKeyword(value)))) return true;
+        return settings.regex_patterns.some(pattern => {
+            try {
+                return new RegExp(pattern, 'iu').test(content);
+            } catch {
+                return false;
+            }
+        });
     }
 
     private isCapsAbuse(content: string, settings: AutoModSettings): boolean {
@@ -227,13 +291,27 @@ export class AutoModeration {
         }
     }
 
-    private async applyAction(
-        member: GuildMember,
-        rule: AutoModRule,
-        settings: AutoModSettings
-    ): Promise<string> {
+    private resolveAction(rule: AutoModRule, settings: AutoModSettings, strikes: number): AutoModAction {
+        const steps = [...settings.escalation_steps]
+            .filter(step => Number.isInteger(step.strikes) && step.strikes > 0)
+            .sort((a, b) => a.strikes - b.strikes);
+        let action = settings.rule_actions[rule] ?? settings.action;
+        for (const step of steps) if (strikes >= step.strikes) action = step.action;
+        if (!steps.length && action === 'timeout' && strikes < settings.strike_threshold) return 'delete';
+        return action;
+    }
+
+    private resolveTimeoutSeconds(settings: AutoModSettings, strikes: number): number {
+        let seconds = settings.timeout_seconds;
+        for (const step of [...settings.escalation_steps].sort((a, b) => a.strikes - b.strikes)) {
+            if (strikes >= step.strikes && step.action === 'timeout' && step.timeout_seconds) seconds = step.timeout_seconds;
+        }
+        return seconds;
+    }
+
+    private async applyAction(member: GuildMember, rule: AutoModRule, action: AutoModAction): Promise<string> {
         const reason = `Auto-modération : ${RULE_LABELS[rule]}`;
-        if (settings.action === 'warn') {
+        if (action === 'warn') {
             const sanctionNumber = await createWarning(member.guild.id, member.id, this.client.user!.id, reason);
             await addModerationHistory(
                 member.guild.id,
@@ -252,11 +330,11 @@ export class AutoModeration {
     private async timeoutMember(
         member: GuildMember,
         rule: AutoModRule,
-        settings: AutoModSettings,
+        timeoutSeconds: number,
         strikes: number
     ): Promise<string> {
         if (!member.moderatable || member.isCommunicationDisabled()) return 'delete';
-        const durationMs = Math.min(settings.timeout_seconds * 1000, 28 * 24 * 60 * 60 * 1000);
+        const durationMs = Math.min(timeoutSeconds * 1000, 28 * 24 * 60 * 60 * 1000);
         const reason = `Auto-modération : ${RULE_LABELS[rule]} (${strikes} infractions)`;
         await member.timeout(durationMs, reason);
         const sanctionNumber = await addModerationHistory(
@@ -265,9 +343,9 @@ export class AutoModeration {
             this.client.user!.id,
             'automod_timeout',
             reason,
-            `${settings.timeout_seconds}s`
+            `${timeoutSeconds}s`
         );
-        return `timeout ${settings.timeout_seconds}s · sanction #${sanctionNumber}`;
+        return `timeout ${timeoutSeconds}s · sanction #${sanctionNumber}`;
     }
 
     private async notifyUser(

--- a/utils/moderation/automodService.ts
+++ b/utils/moderation/automodService.ts
@@ -1,7 +1,14 @@
 import { supabase } from '../../database/supabase.ts';
 
-export type AutoModRule = 'link' | 'invite' | 'spam' | 'duplicate' | 'caps' | 'mentions';
+export type AutoModRule = 'link' | 'invite' | 'spam' | 'duplicate' | 'caps' | 'mentions' | 'keyword';
 export type AutoModAction = 'delete' | 'warn' | 'timeout';
+export type AutoModSource = 'message_create' | 'message_update' | 'native';
+
+export interface AutoModEscalationStep {
+    strikes: number;
+    action: AutoModAction;
+    timeout_seconds?: number;
+}
 
 export interface AutoModSettings {
     guild_id: string;
@@ -28,6 +35,18 @@ export interface AutoModSettings {
     strike_window_seconds: number;
     timeout_seconds: number;
     notify_user: boolean;
+    observation_mode: boolean;
+    anti_keyword_enabled: boolean;
+    blocked_keywords: string[];
+    allowed_keywords: string[];
+    regex_patterns: string[];
+    rule_actions: Partial<Record<AutoModRule, AutoModAction>>;
+    escalation_steps: AutoModEscalationStep[];
+    anti_raid_enabled: boolean;
+    raid_join_count: number;
+    raid_interval_seconds: number;
+    raid_account_age_hours: number;
+    raid_mode_seconds: number;
 }
 
 const DEFAULTS: Omit<AutoModSettings, 'guild_id'> = {
@@ -53,7 +72,19 @@ const DEFAULTS: Omit<AutoModSettings, 'guild_id'> = {
     strike_threshold: 3,
     strike_window_seconds: 3600,
     timeout_seconds: 600,
-    notify_user: true
+    notify_user: true,
+    observation_mode: false,
+    anti_keyword_enabled: false,
+    blocked_keywords: [],
+    allowed_keywords: [],
+    regex_patterns: [],
+    rule_actions: {},
+    escalation_steps: [],
+    anti_raid_enabled: false,
+    raid_join_count: 8,
+    raid_interval_seconds: 20,
+    raid_account_age_hours: 24,
+    raid_mode_seconds: 600
 };
 
 const cache = new Map<string, { settings: AutoModSettings; expiresAt: number }>();
@@ -92,7 +123,9 @@ export async function recordAutoModViolation(
     messageId: string,
     rule: AutoModRule,
     actionTaken: string,
-    excerpt: string
+    excerpt: string,
+    source: AutoModSource = 'message_create',
+    observed = false
 ): Promise<void> {
     const { error } = await supabase.from('guild_automod_violations').insert({
         guild_id: guildId,
@@ -101,9 +134,37 @@ export async function recordAutoModViolation(
         message_id: messageId,
         rule,
         action_taken: actionTaken,
-        excerpt: excerpt.slice(0, 500)
+        excerpt: excerpt.slice(0, 500),
+        source,
+        observed
     });
     if (error) throw new Error(`Enregistrement auto-modération impossible : ${error.message}`);
+}
+
+export interface AutoModStats {
+    total: number;
+    observed: number;
+    byRule: Partial<Record<AutoModRule, number>>;
+}
+
+export async function getAutoModStats(guildId: string, days = 7): Promise<AutoModStats> {
+    const since = new Date(Date.now() - days * 86_400_000).toISOString();
+    const { data, error } = await supabase
+        .from('guild_automod_violations')
+        .select('rule, observed')
+        .eq('guild_id', guildId)
+        .gte('created_at', since)
+        .limit(5000);
+    if (error) throw new Error(`Statistiques auto-modération impossibles : ${error.message}`);
+    const rows = (data ?? []) as Array<{ rule: AutoModRule; observed: boolean }>;
+    return {
+        total: rows.length,
+        observed: rows.filter(row => row.observed).length,
+        byRule: rows.reduce<Partial<Record<AutoModRule, number>>>((counts, row) => {
+            counts[row.rule] = (counts[row.rule] ?? 0) + 1;
+            return counts;
+        }, {})
+    };
 }
 
 export async function getAutoModStrikeCount(guildId: string, userId: string): Promise<number> {

--- a/utils/stats/chart.ts
+++ b/utils/stats/chart.ts
@@ -118,7 +118,7 @@ export async function renderBarChart(
     title: string,
     subtitle: string,
     data: ChartDatum[],
-    color = KEPLER_CHART_COLORS.messages
+    color: string = KEPLER_CHART_COLORS.messages
 ): Promise<Buffer> {
     const items = data.slice(0, 15);
     const maxValue = Math.max(...items.map(item => item.value), 1);

--- a/utils/stats/chart.ts
+++ b/utils/stats/chart.ts
@@ -25,6 +25,8 @@ const CACHE_TTL = 60_000;
 const CACHE_LIMIT = 24;
 const chartCache = new Map<string, CacheEntry>();
 const pendingRenders = new Map<string, Promise<Buffer>>();
+const TEXT_FONT = "'DejaVu Sans', sans-serif";
+const EMOJI_FONT = "'Noto Color Emoji', 'Segoe UI Emoji', 'Apple Color Emoji', 'DejaVu Sans', sans-serif";
 const XML_ENTITIES: Record<string, string> = {
     "&": "&amp;",
     "<": "&lt;",
@@ -41,9 +43,30 @@ function formatNumber(value: number): string {
     return new Intl.NumberFormat('fr-FR', { notation: 'compact', maximumFractionDigits: 1 }).format(value);
 }
 
+function truncateGraphemes(value: string, maxLength: number): string {
+    const graphemes = [...new Intl.Segmenter('fr', { granularity: 'grapheme' }).segment(value)]
+        .map(part => part.segment);
+    return graphemes.length <= maxLength ? value : `${graphemes.slice(0, maxLength - 1).join('')}…`;
+}
+
+function evenlySpacedIndexes(length: number, maximum = 7): Set<number> {
+    if (length <= maximum) return new Set(Array.from({ length }, (_, index) => index));
+    return new Set(Array.from({ length: maximum }, (_, index) =>
+        Math.round(index * (length - 1) / (maximum - 1))
+    ));
+}
+
+function niceMaximum(value: number): number {
+    if (value <= 1) return 1;
+    const magnitude = 10 ** Math.floor(Math.log10(value));
+    const normalized = value / magnitude;
+    return (normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10) * magnitude;
+}
+
 function baseSvg(title: string, subtitle: string, content: string): string {
     return `<svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" xmlns="http://www.w3.org/2000/svg">
         <defs>
+            <clipPath id="bar-label-clip"><rect x="105" y="130" width="175" height="470"/></clipPath>
             <linearGradient id="kepler-bg" x1="0" y1="0" x2="1" y2="1">
                 <stop offset="0" stop-color="${KEPLER_HEX.graphite}"/>
                 <stop offset="1" stop-color="#0C1117"/>
@@ -62,9 +85,9 @@ function baseSvg(title: string, subtitle: string, content: string): string {
         <circle cx="780" cy="32" r="2" fill="${KEPLER_HEX.orbitalBlue}" opacity="0.45"/>
         <rect x="24" y="24" width="1152" height="627" rx="18" fill="url(#kepler-panel)" stroke="${KEPLER_HEX.border}"/>
         <rect x="24" y="24" width="6" height="627" rx="3" fill="${KEPLER_HEX.orbitalBlue}"/>
-        <text x="64" y="57" fill="${KEPLER_HEX.orbitalBlue}" font-family="DejaVu Sans, sans-serif" font-size="13" font-weight="700" letter-spacing="2">KEPLER • CENTRE DE CONTRÔLE</text>
-        <text x="64" y="91" fill="${KEPLER_HEX.lunarWhite}" font-family="DejaVu Sans, sans-serif" font-size="30" font-weight="700">${escapeXml(title)}</text>
-        <text x="64" y="119" fill="${KEPLER_HEX.silver}" font-family="DejaVu Sans, sans-serif" font-size="16">${escapeXml(subtitle)}</text>
+        <text x="64" y="57" fill="${KEPLER_HEX.orbitalBlue}" font-family="${TEXT_FONT}" font-size="13" font-weight="700" letter-spacing="2">KEPLER • CENTRE DE CONTRÔLE</text>
+        <text x="64" y="91" fill="${KEPLER_HEX.lunarWhite}" font-family="${EMOJI_FONT}" font-size="30" font-weight="700">${escapeXml(truncateGraphemes(title, 52))}</text>
+        <text x="64" y="119" fill="${KEPLER_HEX.silver}" font-family="${EMOJI_FONT}" font-size="16">${escapeXml(truncateGraphemes(subtitle, 90))}</text>
         <g transform="translate(1100 74)">
             <circle r="23" fill="none" stroke="${KEPLER_HEX.deepBlue}" stroke-width="1.5"/>
             <ellipse rx="34" ry="12" fill="none" stroke="${KEPLER_HEX.orbitalBlue}" stroke-width="1.5" transform="rotate(-20)"/>
@@ -131,9 +154,10 @@ export async function renderBarChart(
     const rows = items.map((item, index) => {
         const y = chartTop + index * rowHeight;
         const width = Math.max(item.value > 0 ? 4 : 0, (item.value / maxValue) * chartWidth);
+        const label = truncateGraphemes(item.label, 20);
         return `
             <text x="66" y="${y + barHeight - 2}" fill="${KEPLER_HEX.muted}" font-family="DejaVu Sans, sans-serif" font-size="13" font-weight="700">${String(index + 1).padStart(2, '0')}</text>
-            <text x="275" y="${y + barHeight - 2}" text-anchor="end" fill="${KEPLER_HEX.lunarWhite}" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="600">${escapeXml(item.label.slice(0, 24))}</text>
+            <text x="275" y="${y + barHeight - 2}" text-anchor="end" clip-path="url(#bar-label-clip)" fill="${KEPLER_HEX.lunarWhite}" font-family="${EMOJI_FONT}" font-size="16" font-weight="600">${escapeXml(label)}</text>
             <rect x="${chartX}" y="${y}" width="${chartWidth}" height="${barHeight}" rx="6" fill="${KEPLER_HEX.panelRaised}"/>
             <rect x="${chartX}" y="${y}" width="${width}" height="${barHeight}" rx="6" fill="${color}"/>
             <circle cx="${chartX + width}" cy="${y + barHeight / 2}" r="4" fill="${KEPLER_HEX.lunarWhite}"/>
@@ -175,33 +199,38 @@ export async function renderLineChart(
     const plot = { x: 95, y: 160, width: 1040, height: 390 };
 
     const allValues = series.flatMap(item => item.values);
-    const maxValue = Math.max(...allValues, 1);
+    const maxValue = niceMaximum(Math.max(...allValues, 1));
     const pointCount = Math.max(labels.length, ...series.map(item => item.values.length), 1);
     const xFor = (index: number) => plot.x + (index / Math.max(pointCount - 1, 1)) * plot.width;
     const yFor = (value: number) => plot.y + plot.height - (value / maxValue) * plot.height;
 
-    const grid = Array.from({ length: 5 }, (_, index) => {
-        const ratio = index / 4;
+    const tickCount = maxValue <= 1 ? 2 : 5;
+    const grid = Array.from({ length: tickCount }, (_, index) => {
+        const ratio = index / (tickCount - 1);
         const y = plot.y + ratio * plot.height;
         const value = Math.round(maxValue * (1 - ratio));
         return `<line x1="${plot.x}" y1="${y}" x2="${plot.x + plot.width}" y2="${y}" stroke="${KEPLER_HEX.border}" stroke-dasharray="4 8" stroke-width="1"/>
             <text x="80" y="${y + 5}" text-anchor="end" fill="${KEPLER_HEX.muted}" font-family="DejaVu Sans, sans-serif" font-size="14">${escapeXml(formatNumber(value))}</text>`;
     }).join('');
 
-    const lines = series.map(item => {
+    const dotIndexes = evenlySpacedIndexes(pointCount, 12);
+    const lines = series.map((item, seriesIndex) => {
         const points = item.values.map((value, index) => `${xFor(index)},${yFor(value)}`).join(' ');
         const areaPoints = `${plot.x},${plot.y + plot.height} ${points} ${xFor(Math.max(item.values.length - 1, 0))},${plot.y + plot.height}`;
-        const dots = item.values.map((value, index) => `<circle cx="${xFor(index)}" cy="${yFor(value)}" r="4" fill="${KEPLER_HEX.panel}" stroke="${item.color}" stroke-width="3"/>`).join('');
+        const dots = item.values.map((value, index) => dotIndexes.has(index)
+            ? `<circle cx="${xFor(index)}" cy="${yFor(value)}" r="4" fill="${KEPLER_HEX.panel}" stroke="${item.color}" stroke-width="3"/>`
+            : '').join('');
+        const dash = seriesIndex % 2 === 1 ? ' stroke-dasharray="10 7"' : '';
         return `<polygon points="${areaPoints}" fill="${item.color}" opacity="0.08"/>
-            <polyline points="${points}" fill="none" stroke="${item.color}" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>${dots}`;
+            <polyline points="${points}" fill="none" stroke="${item.color}" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"${dash}/>${dots}`;
     }).join('');
 
-    const labelStep = Math.max(1, Math.ceil(labels.length / 8));
-    const xLabels = labels.map((label, index) => index % labelStep === 0 || index === labels.length - 1
+    const visibleLabelIndexes = evenlySpacedIndexes(labels.length, 7);
+    const xLabels = labels.map((label, index) => visibleLabelIndexes.has(index)
         ? `<text x="${xFor(index)}" y="595" text-anchor="middle" fill="${KEPLER_HEX.muted}" font-family="DejaVu Sans, sans-serif" font-size="14">${escapeXml(label)}</text>`
         : '').join('');
-    const legend = series.map((item, index) => `<rect x="${95 + index * 210}" y="620" width="18" height="5" rx="2" fill="${item.color}"/>
-        <text x="${122 + index * 210}" y="627" fill="${KEPLER_HEX.silver}" font-family="DejaVu Sans, sans-serif" font-size="15">${escapeXml(item.label)}</text>`).join('');
+    const legend = series.map((item, index) => `<line x1="${95 + index * 210}" y1="620" x2="${115 + index * 210}" y2="620" stroke="${item.color}" stroke-width="5" stroke-linecap="round"${index % 2 === 1 ? ' stroke-dasharray="7 5"' : ''}/>
+        <text x="${122 + index * 210}" y="627" fill="${KEPLER_HEX.silver}" font-family="${EMOJI_FONT}" font-size="15">${escapeXml(item.label)}</text>`).join('');
 
     const svg = baseSvg(title, subtitle, grid + lines + xLabels + legend);
     return renderCached(JSON.stringify(['line', title, subtitle, labels, series]), svg, title);

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -45,6 +45,8 @@ export const KEPLER_CHART_COLORS = {
     members: KEPLER_HEX.deepBlue,
     channels: KEPLER_HEX.success,
     users: KEPLER_HEX.warning,
+    joins: KEPLER_HEX.success,
+    leaves: KEPLER_HEX.danger,
     neutral: KEPLER_HEX.silver
 } as const;
 

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -41,7 +41,7 @@ export const KEPLER_HEX = {
 
 export const KEPLER_CHART_COLORS = {
     messages: KEPLER_HEX.orbitalBlue,
-    commands: KEPLER_HEX.signalBlue,
+    commands: KEPLER_HEX.warning,
     members: KEPLER_HEX.deepBlue,
     channels: KEPLER_HEX.success,
     users: KEPLER_HEX.warning,

--- a/utils/xp/logger.ts
+++ b/utils/xp/logger.ts
@@ -44,13 +44,16 @@ export async function sendXpLog(
         const details = fields.length
             ? `\n\n${fields.map(field => `**${field.name}** — ${field.value}`).join('\n')}`
             : '';
+        const timestamp = Math.floor(Date.now() / 1000);
         const container = new ContainerBuilder()
             .setAccentColor(KEPLER_COLORS[tone])
             .addTextDisplayComponents(
                 new TextDisplayBuilder().setContent(
                     `-# KEPLER • JOURNAL XP\n## ${title}\n${description}${details}`
                 ),
-                new TextDisplayBuilder().setContent(`-# Journal XP • ${guild.name}`)
+                new TextDisplayBuilder().setContent(
+                    `-# Journal XP • ${guild.name} • <t:${timestamp}:R>`
+                )
             );
         await channel.send({
             components: [container],

--- a/utils/xp/logger.ts
+++ b/utils/xp/logger.ts
@@ -1,9 +1,12 @@
 import {
     ChannelType,
+    ContainerBuilder,
+    MessageFlags,
+    TextDisplayBuilder,
     type Guild
 } from 'discord.js';
 import { supabase } from '../../database/supabase.ts';
-import { createKeplerEmbed, type KeplerTone } from '../theme.ts';
+import { KEPLER_COLORS, type KeplerTone } from '../theme.ts';
 import { logger } from '../logger.ts';
 
 interface XpLogField {
@@ -38,12 +41,22 @@ export async function sendXpLog(
             return false;
         }
 
-        const embed = createKeplerEmbed(tone)
-            .setTitle(title)
-            .setDescription(description)
-            .setFooter({ text: `Journal XP · ${guild.name}` });
-        if (fields.length) embed.addFields(fields);
-        await channel.send({ embeds: [embed], allowedMentions: { parse: [] } });
+        const details = fields.length
+            ? `\n\n${fields.map(field => `**${field.name}** — ${field.value}`).join('\n')}`
+            : '';
+        const container = new ContainerBuilder()
+            .setAccentColor(KEPLER_COLORS[tone])
+            .addTextDisplayComponents(
+                new TextDisplayBuilder().setContent(
+                    `-# KEPLER • JOURNAL XP\n## ${title}\n${description}${details}`
+                ),
+                new TextDisplayBuilder().setContent(`-# Journal XP • ${guild.name}`)
+            );
+        await channel.send({
+            components: [container],
+            flags: MessageFlags.IsComponentsV2,
+            allowedMentions: { parse: [] }
+        });
         return true;
     } catch (error) {
         logger.warn(`Impossible d’envoyer un log XP sur ${guild.id}`, error, 'XP');

--- a/utils/xp/system.ts
+++ b/utils/xp/system.ts
@@ -9,7 +9,7 @@ import { createKeplerEmbed, setRequesterFooter } from '../theme.ts';
 import { logger } from '../logger.ts';
 import { sendXpLog } from './logger.ts';
 
-export const XP_COOLDOWN_SECONDS = 60;
+export const XP_COOLDOWN_SECONDS = 5;
 export const XP_MIN_GAIN = 15;
 export const XP_MAX_GAIN = 25;
 const SETTINGS_CACHE_TTL = 60_000;

--- a/utils/xp/system.ts
+++ b/utils/xp/system.ts
@@ -331,6 +331,7 @@ export async function awardMessageXp(message: Message): Promise<void> {
         ? `\n🎁 Récompense obtenue : ${addedRoles.map((id: string) => `<@&${id}>`).join(', ')}`
         : '';
     if (!settings.announce_level_up) return;
+    const announcementTimestamp = Math.floor(Date.now() / 1000);
     const section = new SectionBuilder()
         .addTextDisplayComponents(
             new TextDisplayBuilder().setContent(
@@ -347,7 +348,9 @@ export async function awardMessageXp(message: Message): Promise<void> {
                 .setAccentColor(KEPLER_COLORS.success)
                 .addSectionComponents(section)
                 .addTextDisplayComponents(
-                    new TextDisplayBuilder().setContent('-# Progression Kepler')
+                    new TextDisplayBuilder().setContent(
+                        `-# Progression Kepler • <t:${announcementTimestamp}:R>`
+                    )
                 )
         ],
         flags: MessageFlags.IsComponentsV2 as MessageFlags.IsComponentsV2,

--- a/utils/xp/system.ts
+++ b/utils/xp/system.ts
@@ -1,11 +1,16 @@
 import {
     ChannelType,
+    ContainerBuilder,
     type Guild,
     type GuildMember,
-    type Message
+    type Message,
+    MessageFlags,
+    SectionBuilder,
+    TextDisplayBuilder,
+    ThumbnailBuilder
 } from 'discord.js';
 import { supabase } from '../../database/supabase.ts';
-import { createKeplerEmbed, setRequesterFooter } from '../theme.ts';
+import { KEPLER_COLORS } from '../theme.ts';
 import { logger } from '../logger.ts';
 import { sendXpLog } from './logger.ts';
 
@@ -92,9 +97,10 @@ export function xpProgress(xp: number): {
     };
 }
 
-export function progressBar(percentage: number, size = 12): string {
-    const filled = Math.round(Math.max(0, Math.min(100, percentage)) / 100 * size);
-    return `${'▰'.repeat(filled)}${'▱'.repeat(size - filled)}`;
+export function progressBar(percentage: number, size = 10): string {
+    const normalized = Math.max(0, Math.min(100, percentage));
+    const filled = normalized === 100 ? size : Math.floor(normalized / 100 * size);
+    return `${'█'.repeat(filled)}${'░'.repeat(size - filled)}`;
 }
 
 export async function getXpProfile(guildId: string, userId: string): Promise<XpProfile | null> {
@@ -322,18 +328,31 @@ export async function awardMessageXp(message: Message): Promise<void> {
         ]
     );
     const roleLine = addedRoles.length
-        ? `\nRécompense obtenue : ${addedRoles.map((id: string) => `<@&${id}>`).join(', ')}`
+        ? `\n🎁 Récompense obtenue : ${addedRoles.map((id: string) => `<@&${id}>`).join(', ')}`
         : '';
     if (!settings.announce_level_up) return;
-    const embed = setRequesterFooter(
-        createKeplerEmbed('success')
-            .setTitle(`Niveau ${result.level} atteint`)
-            .setDescription(
+    const section = new SectionBuilder()
+        .addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(
+                `-# KEPLER • PROGRESSION XP\n## Niveau ${result.level} atteint !\n` +
                 `Bravo ${message.author}, tu passes au **niveau ${result.level}**.${roleLine}`
-            ),
-        message.author,
-        'Progression Kepler'
-    );
+            )
+        )
+        .setThumbnailAccessory(
+            new ThumbnailBuilder().setURL(message.author.displayAvatarURL({ forceStatic: true }))
+        );
+    const announcement = {
+        components: [
+            new ContainerBuilder()
+                .setAccentColor(KEPLER_COLORS.success)
+                .addSectionComponents(section)
+                .addTextDisplayComponents(
+                    new TextDisplayBuilder().setContent('-# Progression Kepler')
+                )
+        ],
+        flags: MessageFlags.IsComponentsV2 as MessageFlags.IsComponentsV2,
+        allowedMentions: { parse: [] as never[] }
+    };
     if (settings.level_up_channel_id && settings.level_up_channel_id !== message.channel.id) {
         try {
             const configuredChannel = await message.guild.channels.fetch(settings.level_up_channel_id);
@@ -342,7 +361,7 @@ export async function awardMessageXp(message: Message): Promise<void> {
                 (configuredChannel.type === ChannelType.GuildText ||
                     configuredChannel.type === ChannelType.GuildAnnouncement)
             ) {
-                await configuredChannel.send({ embeds: [embed] });
+                await configuredChannel.send(announcement);
                 return;
             }
             logger.warn('Salon d’annonce XP configuré introuvable ou invalide', undefined, 'XP');
@@ -350,7 +369,7 @@ export async function awardMessageXp(message: Message): Promise<void> {
             logger.warn('Envoi dans le salon d’annonce XP impossible, utilisation du salon courant', error, 'XP');
         }
     }
-    await message.channel.send({ embeds: [embed] });
+    await message.channel.send(announcement);
 }
 
 export function canManageRewardRole(guild: Guild, roleId: string): boolean {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.0.1",
+  "version": "1.1.0",
   "codename": "Kepler",
-  "releaseDate": "2026-07-31",
-  "changelog": "Kepler 1.0.1 - Correction de la synchronisation et de l'affichage des invitations existantes."
+  "releaseDate": "2026-08-07",
+  "changelog": "Kepler 1.1.0 - AutoMod enrichi, Components V2, statistiques serveur, XP et invitations améliorés."
 }


### PR DESCRIPTION
## Résumé

Prépare Kepler 1.1.0 avec un centre de configuration modernisé, une auto-modération enrichie et de nouvelles interfaces Components V2 pour les modules XP et invitations.

## Changements principaux

- enrichit l'AutoMod avec observation, filtres, seuils, exemptions, anti-raid et actions par règle ;
- réorganise `/settings` et migre le panneau vers Components V2 ;
- améliore `/graph`, ajoute le suivi des arrivées et départs et fiabilise le rendu des emojis ;
- modernise les profils, annonces, journaux et classements XP ;
- fixe le cooldown XP par défaut des nouvelles configurations à 5 secondes ;
- migre les commandes d'invitations vers Components V2 ;
- ajoute une pagination avec flèches et accès direct aux classements XP et invitations ;
- met à jour Discord.js, l'image Docker et la documentation de release ;
- publie la roadmap V1.2 à Kepler 2.0.

## Base de données

Appliquer dans l'ordre :

1. `20260804_extend_automod_v1_1.sql`
2. `20260805_add_member_flow_stats.sql`
3. `20260806_set_default_xp_cooldown.sql`

Les réglages XP existants conservent leur cooldown actuel.

## Impact

- interface d'administration plus lisible et homogène ;
- règles de modération plus précises et qualifiables en mode observation ;
- statistiques serveur plus complètes ;
- progression XP plus dynamique pour les nouvelles configurations ;
- classements consultables au-delà de la première page.

## Validation

- `git diff --check` validé ;
- JSON de version validé en `1.1.0` ;
- contrôles TypeScript ciblés exécutés sur les modules modifiés ;
- 10 erreurs TypeScript historiques restent présentes hors du périmètre de cette release ;
- qualification fonctionnelle Discord et migrations de préproduction encore à valider selon `RELEASE.md`.
